### PR TITLE
fixed? mask calculation for RegisterBits

### DIFF
--- a/Adafruit_BusIO_Register.cpp
+++ b/Adafruit_BusIO_Register.cpp
@@ -229,7 +229,7 @@ Adafruit_BusIO_RegisterBits::Adafruit_BusIO_RegisterBits(Adafruit_BusIO_Register
 uint32_t Adafruit_BusIO_RegisterBits::read(void) {
   uint32_t val = _register->read();
   val >>= _shift;
-  return val & ((1 << (_bits+1)) - 1);
+  return val & ((1 << (_bits)) - 1);
 }
 
 
@@ -241,7 +241,7 @@ void Adafruit_BusIO_RegisterBits::write(uint32_t data) {
   uint32_t val = _register->read();
 
   // mask off the data before writing
-  uint32_t mask = (1 << (_bits+1)) - 1;
+  uint32_t mask = (1 << (_bits)) - 1;
   data &= mask;
 
   mask <<= _shift;


### PR DESCRIPTION
I think I found a bug, it was certainly breaking things for me. I'm hesitant to say for sure because this has been for a while and seems like it would have caused more issues 🤷‍♂ 

Here's me demoing the before/after in python for legibility:
![image](https://user-images.githubusercontent.com/1183985/66693169-0addd500-ec5b-11e9-9be1-fb32a8b1f8be.png)
