### PR TITLE
SPI: Add Infineon XMC boards to BitOrder quirk

### DIFF
--- a/Adafruit_SPIDevice.h
+++ b/Adafruit_SPIDevice.h
@@ -24,7 +24,8 @@ typedef enum _BitOrder {
 // Some platforms have a BitOrder enum but its named MSBFIRST/LSBFIRST
 #if defined(ARDUINO_ARCH_SAMD) || defined(__SAM3X8E__) ||                      \
     defined(NRF52_SERIES) || defined(ARDUINO_ARCH_ARDUINO_CORE_STM32) ||       \
-    defined(ARDUINO_ARCH_MEGAAVR) || defined(_STM32_DEF_)
+    defined(ARDUINO_ARCH_MEGAAVR) || defined(_STM32_DEF_) ||                   \
+    defined(XMC_BOARD)
 #define SPI_BITORDER_MSBFIRST MSBFIRST
 #define SPI_BITORDER_LSBFIRST LSBFIRST
 #endif


### PR DESCRIPTION
As many (all?) ARM Cortex based chips, Infineon xmc boards also need
this quirk for BusIO to compile.

Original commit: 4921ca2cea2ebf15adab04f195f1d898aaa44d75 ("Update Adafruit_SPIDevice.h")
XMC for arduino: https://github.com/Infineon/XMC-for-Arduino