### PR TITLE
maxBufferSize should be size_t type since all the length are size_t type

### DIFF
--- a/Adafruit_I2CDevice.h
+++ b/Adafruit_I2CDevice.h
@@ -20,13 +20,13 @@ public:
 
   /*!   @brief  How many bytes we can read in a transaction
    *    @return The size of the Wire receive/transmit buffer */
-  uint16_t maxBufferSize() { return _maxBufferSize; }
+  size_t maxBufferSize() { return _maxBufferSize; }
 
 private:
   uint8_t _addr;
   TwoWire *_wire;
   bool _begun;
-  uint16_t _maxBufferSize;
+  size_t _maxBufferSize;
 };
 
 #endif // Adafruit_I2CDevice_h


### PR DESCRIPTION
Hello,

It seems that maxBufferSize should be size_t since it is the size of buffer.