### PR TITLE
When write is done before a read, the write should not release the I2C bus since a read will be done right after

### DIFF
--- a/Adafruit_I2CDevice.cpp
+++ b/Adafruit_I2CDevice.cpp
@@ -197,17 +197,17 @@ bool Adafruit_I2CDevice::read(uint8_t *buffer, size_t len, bool stop) {
  *    @param  write_len Number of bytes from buffer to write.
  *    @param  read_buffer Pointer to buffer of data to read into.
  *    @param  read_len Number of bytes from buffer to read.
- *    @param  stop Whether to send an I2C STOP signal between the write and read
+ *    @param  stop Whether to send an I2C STOP signal after the read.
  *    @return True if write & read was successful, otherwise false.
  */
 bool Adafruit_I2CDevice::write_then_read(uint8_t *write_buffer,
                                          size_t write_len, uint8_t *read_buffer,
                                          size_t read_len, bool stop) {
-  if (!write(write_buffer, write_len, stop)) {
+  if (!write(write_buffer, write_len, false)) {
     return false;
   }
 
-  return read(read_buffer, read_len);
+  return read(read_buffer, read_len, stop);
 }
 
 /*!

--- a/Adafruit_I2CDevice.h
+++ b/Adafruit_I2CDevice.h
@@ -16,7 +16,7 @@ public:
              uint8_t *prefix_buffer = NULL, size_t prefix_len = 0);
   bool write_then_read(uint8_t *write_buffer, size_t write_len,
                        uint8_t *read_buffer, size_t read_len,
-                       bool stop = false);
+                       bool stop = true);
 
   /*!   @brief  How many bytes we can read in a transaction
    *    @return The size of the Wire receive/transmit buffer */


### PR DESCRIPTION
When write is done before a read, the write should not release the I2C bus since a read will be done right after.

Also changing the default value for stop in write_then_read() since the bus should be released by default.