### PR TITLE
fixing support for SPI modes 2 & 3

### DIFF
--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -123,7 +123,7 @@ void Adafruit_SPIDevice::transfer(uint8_t *buffer, size_t len) {
     // Serial.print(send, HEX);
     for (int b = 7; b >= 0; b--) {
       reply <<= 1;
-      if (_dataMode == SPI_MODE0) {
+      if (_dataMode == SPI_MODE0 || _dataMode == SPI_MODE2) {
         if (_mosi != -1) {
           digitalWrite(_mosi, send & (1 << b));
         }
@@ -133,7 +133,7 @@ void Adafruit_SPIDevice::transfer(uint8_t *buffer, size_t len) {
         }
         digitalWrite(_sck, LOW);
       }
-      if (_dataMode == SPI_MODE1) {
+      if (_dataMode == SPI_MODE1 || _dataMode == SPI_MODE3) {
         digitalWrite(_sck, HIGH);
         if (_mosi != -1) {
           digitalWrite(_mosi, send & (1 << b));


### PR DESCRIPTION
This patch allowed me to use BusIO with the ADXL343 which uses SPI mode 3:
![image](https://user-images.githubusercontent.com/1183985/80020594-26d5f500-848e-11ea-990f-9e8c5b35cf17.png)
