### PR TITLE
Fix side effect where spi_begin(); causes SS to be output high

### DIFF
--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -64,7 +64,16 @@ bool Adafruit_SPIDevice::begin(void) {
   digitalWrite(_cs, HIGH);
 
   if (_spi) { // hardware SPI
+    // store the current pin state
+    uint8_t SS_state = digitalRead(SS);
+    // store the current pin mode
+    uint8_t SS_mode = ~(DDRB & bit(SS));  
     _spi->begin();
+    DDRB |= SS_mode;
+    // restore the mode and write if mode is OUTPUT
+    if ( SS_mode != 0){
+      digitalWrite(SS, SS_state);
+    }
   } else {
     pinMode(_sck, OUTPUT);
 


### PR DESCRIPTION
If using a CS pin other than SS, Adafruit_SPIDevice::begin(void) calls _spi->begin() which causes SS to be set as output and high. Change is a workaround to store and restore the state of the SS pin after the call.

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--
Save the state of the SS pin prior to _spi->begin(), eliminating a side effect where _spi->begin() would set the SS pin to be an output and high after the call, even if _cs wasn't the same as SS.

- **Describe any known limitations with your change.**  None that I'm aware of; it simply undoes the arduino library's change.

- **Please run any tests or examples that can exercise your modified code.** Without the change, this code results in pin 10 high (on an arduino uno), despite using pin 8 for CS.
With the change, pin 10 has been restored.

```
#include <Arduino.h>
#include <Wire.h>
#include <SPI.h>
#include <Adafruit_MAX31855.h>

#define MAXCS 8
Adafruit_MAX31855 thermocouple(MAXCS);

void setup(){
    delay(500); // wait for MAX chip to stabilize    
    thermocouple.begin();
}

void loop(){}
```
