### PR TITLE
Remove delay from write_then_read()

### DIFF
--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -301,7 +301,6 @@ bool Adafruit_SPIDevice::write_then_read(uint8_t *write_buffer,
   }
   DEBUG_SERIAL.println();
 #endif
-  delay(10);
 
   // do the reading
   for (size_t i = 0; i < read_len; i++) {

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit BusIO
-version=1.2.5
+version=1.2.6
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=This is a library for abstracting away UART, I2C and SPI interfacing


### PR DESCRIPTION
For #24 

Tested with MAX31856 and UNO.

**BEFORE**
![with_delay](https://user-images.githubusercontent.com/8755041/82489035-d30ef980-9a95-11ea-9630-9facd8620c10.jpg)

**AFTER**
![without_delay](https://user-images.githubusercontent.com/8755041/82489046-d73b1700-9a95-11ea-9fa6-7626ad60f038.jpg)
