### PR TITLE
Add support for more megaAVR targets

### DIFF
--- a/Adafruit_SPIDevice.h
+++ b/Adafruit_SPIDevice.h
@@ -8,7 +8,11 @@
     defined(ESP8266) || defined(TEENSYDUINO) ||                                \
     defined(ARDUINO_ARCH_SPRESENSE) || defined(ARDUINO_attinyxy7) ||           \
     defined(ARDUINO_attinyxy6) || defined(ARDUINO_attinyxy4) ||                \
-    defined(ARDUINO_attinyxy2)
+    defined(ARDUINO_attinyxy2) || defined(ARDUINO_AVR_ATmega4809) ||           \
+    defined(ARDUINO_AVR_ATmega4808) || defined(ARDUINO_AVR_ATmega3209) ||      \
+    defined(ARDUINO_AVR_ATmega3208) || defined(ARDUINO_AVR_ATmega1609) ||      \
+    defined(ARDUINO_AVR_ATmega1608) || defined(ARDUINO_AVR_ATmega809) ||       \
+    defined(ARDUINO_AVR_ATmega808)
 typedef enum _BitOrder {
   SPI_BITORDER_MSBFIRST = MSBFIRST,
   SPI_BITORDER_LSBFIRST = LSBFIRST,


### PR DESCRIPTION
Specifically ATmega4809/3209/1609/809 and ATmega4808/3208/1608/808 that's supported through [MegaCoreX](https://github.com/MCUdude/MegaCoreX).
