### PR TITLE
Help library build with Spark/Particle

### DIFF
--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -112,7 +112,16 @@ bool Adafruit_SPIDevice::begin(void) {
 void Adafruit_SPIDevice::transfer(uint8_t *buffer, size_t len) {
   if (_spi) {
     // hardware SPI is easy
-    _spi->transfer(buffer, len);
+    #ifdef SPARK
+      // Spark uses asynchronous DMA for multi-byte transfers; 
+      // just use the single-byte method for sync transfers.
+      for (size_t i = 0; i < len; i++) {
+        _spi->transfer(buffer[i]);
+      }
+    #else
+      _spi->transfer(buffer, len);
+    #endif
+
     return;
   }
 

--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -114,11 +114,7 @@ void Adafruit_SPIDevice::transfer(uint8_t *buffer, size_t len) {
     // hardware SPI is easy
 
 #ifdef SPARK
-    // Spark uses asynchronous DMA for multi-byte transfers; 
-    // just use the single-byte method for sync transfers.
-    for (size_t i = 0; i < len; i++) {
-      _spi->transfer(buffer[i]);
-    }
+    _spi->transfer(buffer, buffer, len, NULL);
 #else
     _spi->transfer(buffer, len);
 #endif

--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -112,15 +112,16 @@ bool Adafruit_SPIDevice::begin(void) {
 void Adafruit_SPIDevice::transfer(uint8_t *buffer, size_t len) {
   if (_spi) {
     // hardware SPI is easy
-    #ifdef SPARK
-      // Spark uses asynchronous DMA for multi-byte transfers; 
-      // just use the single-byte method for sync transfers.
-      for (size_t i = 0; i < len; i++) {
-        _spi->transfer(buffer[i]);
-      }
-    #else
-      _spi->transfer(buffer, len);
-    #endif
+
+#ifdef SPARK
+    // Spark uses asynchronous DMA for multi-byte transfers; 
+    // just use the single-byte method for sync transfers.
+    for (size_t i = 0; i < len; i++) {
+      _spi->transfer(buffer[i]);
+    }
+#else
+    _spi->transfer(buffer, len);
+#endif
 
     return;
   }

--- a/Adafruit_SPIDevice.h
+++ b/Adafruit_SPIDevice.h
@@ -5,7 +5,7 @@
 
 // some modern SPI definitions don't have BitOrder enum
 #if (defined(__AVR__) && !defined(ARDUINO_ARCH_MEGAAVR)) ||                    \
-    defined(ESP8266) || defined(TEENSYDUINO) ||                                \
+    defined(ESP8266) || defined(TEENSYDUINO) || defined(SPARK) ||              \
     defined(ARDUINO_ARCH_SPRESENSE) || defined(ARDUINO_attinyxy7) ||           \
     defined(ARDUINO_attinyxy6) || defined(ARDUINO_attinyxy4) ||                \
     defined(ARDUINO_attinyxy2) || defined(ARDUINO_AVR_ATmega4809) ||           \

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit BusIO
-version=1.4.1
+version=1.4.2
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=This is a library for abstracting away UART, I2C and SPI interfacing


### PR DESCRIPTION
This change lets this library build on [Particle](https://particle.io) devices.

Two changes are required:
- fixing the `#ifdef` for processor architecture selection when defining the `BitOrder` enum
- adjusting to the Particle built-in SPI library, which seems to only support bulk transfers via async DMA

I think that `#ifdef SPARK` is the right selector for this (rather than, say, `PARTICLE`) because these seem to be design decisions inherited from the Spark library that Particle uses, rather than something Particle-specific, but I'm not positive.

Risks: This builds, but I'm not using any SPI in my project so I can't verify that this works. (My project just needs this to build so the SSD1306 dependency works, which I'm just using with I2C.)