### PR TITLE
Fix support for megaTinyCore, add DxCore support

### DIFF
--- a/Adafruit_SPIDevice.h
+++ b/Adafruit_SPIDevice.h
@@ -6,9 +6,8 @@
 // some modern SPI definitions don't have BitOrder enum
 #if (defined(__AVR__) && !defined(ARDUINO_ARCH_MEGAAVR)) ||                    \
     defined(ESP8266) || defined(TEENSYDUINO) || defined(SPARK) ||              \
-    defined(ARDUINO_ARCH_SPRESENSE) || defined(ARDUINO_attinyxy7) ||           \
-    defined(ARDUINO_attinyxy6) || defined(ARDUINO_attinyxy4) ||                \
-    defined(ARDUINO_attinyxy2) || defined(ARDUINO_AVR_ATmega4809) ||           \
+    defined(ARDUINO_ARCH_SPRESENSE) || defined(MEGATINYCORE) ||                \
+    defined(DXCORE) || defined(ARDUINO_AVR_ATmega4809) ||                      \
     defined(ARDUINO_AVR_ATmega4808) || defined(ARDUINO_AVR_ATmega3209) ||      \
     defined(ARDUINO_AVR_ATmega3208) || defined(ARDUINO_AVR_ATmega1609) ||      \
     defined(ARDUINO_AVR_ATmega1608) || defined(ARDUINO_AVR_ATmega809) ||       \


### PR DESCRIPTION
Testing for the define from build.board was not a good test (I recently updated them to refer to the specific part, instead of just the number of pins) - instead, test for the MEGATINYCORE define, (currently provided by Arduino.h - but the next update will move it to platform.txt), and will be present in all future versions of megaTinyCore. Also added a test to check for DxCore, which supports the new AVR Dx-series parts, and does SPI bit order in the same way. I confirmed that the examples now compile again on megaTinyCore 2.1.x with this change - and now compile for DxCore as well (in DxCore, the DXCORE define is already provided by platform.txt).