### PR TITLE
Make compatible with Heltec's CubeCell Arduino-core

### DIFF
--- a/Adafruit_SPIDevice.h
+++ b/Adafruit_SPIDevice.h
@@ -17,21 +17,13 @@ typedef enum _BitOrder {
   SPI_BITORDER_LSBFIRST = LSBFIRST,
 } BitOrder;
 
-#elif defined(ESP32)
+#elif defined(ESP32) || defined(__ASR6501__)
 
 // some modern SPI definitions don't have BitOrder enum and have different SPI
 // mode defines
 typedef enum _BitOrder {
   SPI_BITORDER_MSBFIRST = SPI_MSBFIRST,
   SPI_BITORDER_LSBFIRST = SPI_LSBFIRST,
-} BitOrder;
-
-#elif defined(__ASR6501__)
-#include <Arduino.h>
-typedef enum _BitOrder
-{
-  SPI_BITORDER_MSBFIRST = MSBFIRST,
-  SPI_BITORDER_LSBFIRST = LSBFIRST,
 } BitOrder;
 
 #else

--- a/Adafruit_SPIDevice.h
+++ b/Adafruit_SPIDevice.h
@@ -26,6 +26,14 @@ typedef enum _BitOrder {
   SPI_BITORDER_LSBFIRST = SPI_LSBFIRST,
 } BitOrder;
 
+#elif defined(__ASR6501__)
+#include <Arduino.h>
+typedef enum _BitOrder
+{
+  SPI_BITORDER_MSBFIRST = MSBFIRST,
+  SPI_BITORDER_LSBFIRST = LSBFIRST,
+} BitOrder;
+
 #else
 // Some platforms have a BitOrder enum but its named MSBFIRST/LSBFIRST
 #define SPI_BITORDER_MSBFIRST MSBFIRST
@@ -47,7 +55,9 @@ typedef uint32_t BusIO_PortMask;
     !defined(ARDUINO_ARCH_MBED)
 typedef volatile uint32_t BusIO_PortReg;
 typedef uint32_t BusIO_PortMask;
+#if not defined(__ASR6501__)
 #define BUSIO_USE_FAST_PINIO
+#endif
 
 #else
 #undef BUSIO_USE_FAST_PINIO


### PR DESCRIPTION
The functions fast pin-I/O uses are currently missing, so don't define BUSIO_USE_FAST_PINIO if __ASR6501__ has been defined. Also, we need typedef for BitOrder, but it refuses to compile without also including Arduino.h, at least under PlatformIO.