### PR TITLE
Buffer arguments of I2CDevice write functions are changed to const so that the …

### DIFF
--- a/Adafruit_I2CDevice.cpp
+++ b/Adafruit_I2CDevice.cpp
@@ -67,7 +67,8 @@ bool Adafruit_I2CDevice::detected(void) {
  *    @return True if write was successful, otherwise false.
  */
 bool Adafruit_I2CDevice::write(const uint8_t *buffer, size_t len, bool stop,
-                               const uint8_t *prefix_buffer, size_t prefix_len) {
+                               const uint8_t *prefix_buffer,
+                               size_t prefix_len) {
   if ((len + prefix_len) > maxBufferSize()) {
     // currently not guaranteed to work if more than 32 bytes!
     // we will need to find out if some platforms have larger

--- a/Adafruit_I2CDevice.cpp
+++ b/Adafruit_I2CDevice.cpp
@@ -66,8 +66,8 @@ bool Adafruit_I2CDevice::detected(void) {
  *    @param  stop Whether to send an I2C STOP signal on write
  *    @return True if write was successful, otherwise false.
  */
-bool Adafruit_I2CDevice::write(uint8_t *buffer, size_t len, bool stop,
-                               uint8_t *prefix_buffer, size_t prefix_len) {
+bool Adafruit_I2CDevice::write(const uint8_t *buffer, size_t len, bool stop,
+                               const uint8_t *prefix_buffer, size_t prefix_len) {
   if ((len + prefix_len) > maxBufferSize()) {
     // currently not guaranteed to work if more than 32 bytes!
     // we will need to find out if some platforms have larger
@@ -200,7 +200,7 @@ bool Adafruit_I2CDevice::read(uint8_t *buffer, size_t len, bool stop) {
  *    @param  stop Whether to send an I2C STOP signal between the write and read
  *    @return True if write & read was successful, otherwise false.
  */
-bool Adafruit_I2CDevice::write_then_read(uint8_t *write_buffer,
+bool Adafruit_I2CDevice::write_then_read(const uint8_t *write_buffer,
                                          size_t write_len, uint8_t *read_buffer,
                                          size_t read_len, bool stop) {
   if (!write(write_buffer, write_len, stop)) {

--- a/Adafruit_I2CDevice.cpp
+++ b/Adafruit_I2CDevice.cpp
@@ -58,10 +58,12 @@ bool Adafruit_I2CDevice::detected(void) {
 /*!
  *    @brief  Write a buffer or two to the I2C device. Cannot be more than
  * maxBufferSize() bytes.
- *    @param  buffer Pointer to buffer of data to write
+ *    @param  buffer Pointer to buffer of data to write. This is const to
+ *            ensure the content of this buffer doesn't change.
  *    @param  len Number of bytes from buffer to write
  *    @param  prefix_buffer Pointer to optional array of data to write before
- * buffer. Cannot be more than maxBufferSize() bytes.
+ * buffer. Cannot be more than maxBufferSize() bytes. This is const to
+ *            ensure the content of this buffer doesn't change.
  *    @param  prefix_len Number of bytes from prefix buffer to write
  *    @param  stop Whether to send an I2C STOP signal on write
  *    @return True if write was successful, otherwise false.

--- a/Adafruit_I2CDevice.h
+++ b/Adafruit_I2CDevice.h
@@ -12,9 +12,9 @@ public:
   bool detected(void);
 
   bool read(uint8_t *buffer, size_t len, bool stop = true);
-  bool write(uint8_t *buffer, size_t len, bool stop = true,
-             uint8_t *prefix_buffer = NULL, size_t prefix_len = 0);
-  bool write_then_read(uint8_t *write_buffer, size_t write_len,
+  bool write(const uint8_t *buffer, size_t len, bool stop = true,
+             const uint8_t *prefix_buffer = NULL, size_t prefix_len = 0);
+  bool write_then_read(const uint8_t *write_buffer, size_t write_len,
                        uint8_t *read_buffer, size_t read_len,
                        bool stop = false);
   bool setSpeed(uint32_t desiredclk);

--- a/Adafruit_I2CDevice.h
+++ b/Adafruit_I2CDevice.h
@@ -1,3 +1,6 @@
+/*!
+ * @file Adafruit_I2CDevice.h
+ */
 #include <Wire.h>
 
 #ifndef Adafruit_I2CDevice_h
@@ -12,8 +15,53 @@ public:
   bool detected(void);
 
   bool read(uint8_t *buffer, size_t len, bool stop = true);
+  /**************************************************************************/
+  /*!
+   * @brief  Writes to a I2C device register.
+   *
+   * @param  buffer
+   *         A pointer to a buffer containing data bytes.
+   *         
+   * @param  len
+   *         Number of bytes to write from the previous buffer.
+   *
+   * @param  stop
+   *         If a stop bit needs to be sent at the end of the transmission.
+   *
+   * @param  prefix_buffer
+   *         A pointer to a buffer containing bytes that needs to be send
+   *         before data bytes (e.g. register address).
+   *
+   * @param  prefix_len
+   *         Number of bytes to write from prefix_buffer.
+   *
+   * @return True if the event read was successful, otherwise false.
+   */
+  /**************************************************************************/
   bool write(const uint8_t *buffer, size_t len, bool stop = true,
              const uint8_t *prefix_buffer = NULL, size_t prefix_len = 0);
+  /**************************************************************************/
+  /*!
+   * @brief  Writes to and then read from a I2C device register.
+   *
+   * @param  write_buffer
+   *         A pointer to a buffer containing write bytes.
+   *         
+   * @param  write_len
+   *         Number of bytes to write from the previous buffer.
+   *
+   * @param  read_buffer
+   *         A pointer to a buffer to store bytes from the read operation.
+   *
+   * @param  read_len
+   *         Number of bytes to read.
+   *
+   * @param  stop
+   *         If a stop bit needs to be sent at the end of the transmission.
+   *
+   * @return True if the event read was successful, otherwise false.
+   */
+  /**************************************************************************/
   bool write_then_read(const uint8_t *write_buffer, size_t write_len,
                        uint8_t *read_buffer, size_t read_len,
                        bool stop = false);

--- a/Adafruit_I2CDevice.h
+++ b/Adafruit_I2CDevice.h
@@ -1,6 +1,3 @@
-/*!
- * @file Adafruit_I2CDevice.h
- */
 #include <Wire.h>
 
 #ifndef Adafruit_I2CDevice_h
@@ -15,53 +12,8 @@ public:
   bool detected(void);
 
   bool read(uint8_t *buffer, size_t len, bool stop = true);
-  /**************************************************************************/
-  /*!
-   * @brief  Writes to a I2C device register.
-   *
-   * @param  buffer
-   *         A pointer to a buffer containing data bytes.
-   *         
-   * @param  len
-   *         Number of bytes to write from the previous buffer.
-   *
-   * @param  stop
-   *         If a stop bit needs to be sent at the end of the transmission.
-   *
-   * @param  prefix_buffer
-   *         A pointer to a buffer containing bytes that needs to be send
-   *         before data bytes (e.g. register address).
-   *
-   * @param  prefix_len
-   *         Number of bytes to write from prefix_buffer.
-   *
-   * @return True if the event read was successful, otherwise false.
-   */
-  /**************************************************************************/
   bool write(const uint8_t *buffer, size_t len, bool stop = true,
              const uint8_t *prefix_buffer = NULL, size_t prefix_len = 0);
-  /**************************************************************************/
-  /*!
-   * @brief  Writes to and then read from a I2C device register.
-   *
-   * @param  write_buffer
-   *         A pointer to a buffer containing write bytes.
-   *         
-   * @param  write_len
-   *         Number of bytes to write from the previous buffer.
-   *
-   * @param  read_buffer
-   *         A pointer to a buffer to store bytes from the read operation.
-   *
-   * @param  read_len
-   *         Number of bytes to read.
-   *
-   * @param  stop
-   *         If a stop bit needs to be sent at the end of the transmission.
-   *
-   * @return True if the event read was successful, otherwise false.
-   */
-  /**************************************************************************/
   bool write_then_read(const uint8_t *write_buffer, size_t write_len,
                        uint8_t *read_buffer, size_t read_len,
                        bool stop = false);


### PR DESCRIPTION
…functions cannot change the content of the buffer. Also, if the I2C device's register addresses are define using const rather than #define, the functions can accept those too.


