### PR TITLE
Update Adafruit_SPIDevice.cpp

### DIFF
--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -122,7 +122,7 @@ void Adafruit_SPIDevice::transfer(uint8_t *buffer, size_t len) {
 #else
     _spi->transfer(buffer, len);
 #endif
-  return;
+    return;
   }
 
   uint8_t startbit;

--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -116,8 +116,9 @@ void Adafruit_SPIDevice::transfer(uint8_t *buffer, size_t len) {
 #ifdef SPARK
     _spi->transfer(buffer, buffer, len, NULL);
 #else
-    for(size_t i = 0; i < len; i++ )
+    for (size_t i = 0; i < len; i++) {
       _spi->transfer(buffer[i]);
+    }
 #endif
 
     return;

--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -115,10 +115,12 @@ void Adafruit_SPIDevice::transfer(uint8_t *buffer, size_t len) {
 
 #ifdef SPARK
     _spi->transfer(buffer, buffer, len, NULL);
-#else
+#elsif STM32
     for (size_t i = 0; i < len; i++) {
       _spi->transfer(buffer[i]);
     }
+#else
+        _spi->transfer(buffer, len);
 #endif
 
     return;

--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -122,9 +122,7 @@ void Adafruit_SPIDevice::transfer(uint8_t *buffer, size_t len) {
 #else
     _spi->transfer(buffer, len);
 #endif
-
-
-    return;
+  return;
   }
 
   uint8_t startbit;

--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -116,7 +116,8 @@ void Adafruit_SPIDevice::transfer(uint8_t *buffer, size_t len) {
 #ifdef SPARK
     _spi->transfer(buffer, buffer, len, NULL);
 #else
-    _spi->transfer(buffer, len);
+    for(i = 0; i < len; i++ )
+      _spi->transfer(buffer[i]);
 #endif
 
     return;

--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -116,7 +116,7 @@ void Adafruit_SPIDevice::transfer(uint8_t *buffer, size_t len) {
 #ifdef SPARK
     _spi->transfer(buffer, buffer, len, NULL);
 #else
-    for(i = 0; i < len; i++ )
+    for(size_t i = 0; i < len; i++ )
       _spi->transfer(buffer[i]);
 #endif
 

--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -113,17 +113,16 @@ void Adafruit_SPIDevice::transfer(uint8_t *buffer, size_t len) {
   if (_spi) {
     // hardware SPI is easy
 
-#ifdef SPARK
+#if defined(SPARK)
     _spi->transfer(buffer, buffer, len, NULL);
-#else
-#ifdef STM32
+#elif defined(STM32)
     for (size_t i = 0; i < len; i++) {
       _spi->transfer(buffer[i]);
     }
 #else
     _spi->transfer(buffer, len);
 #endif
-#endif
+
 
     return;
   }

--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -115,12 +115,14 @@ void Adafruit_SPIDevice::transfer(uint8_t *buffer, size_t len) {
 
 #ifdef SPARK
     _spi->transfer(buffer, buffer, len, NULL);
-#elsif STM32
+#else
+#ifdef STM32
     for (size_t i = 0; i < len; i++) {
       _spi->transfer(buffer[i]);
     }
 #else
-        _spi->transfer(buffer, len);
+    _spi->transfer(buffer, len);
+#endif
 #endif
 
     return;


### PR DESCRIPTION
The SPI.cpp that the STM32 project uses does not have a transfer method with both a buffer and a length.  Changes to this file uses a transfer method that just needs a single 8 bit character.

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.
