### PR TITLE
Release memory allocated in constructor to avoid memory leak

### DIFF
--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -70,6 +70,14 @@ Adafruit_SPIDevice::Adafruit_SPIDevice(int8_t cspin, int8_t sckpin,
   _spi = NULL;
 }
 
+// release memory allocated in constructors
+Adafruit_SPIDevice::~Adafruit_SPIDevice() {
+  if (_spiSetting) {
+    delete _spiSetting;
+    _spiSetting = nullptr;
+  }
+}
+
 /*!
  *    @brief  Initializes SPI bus and sets CS pin high
  *    @return Always returns true because there's no way to test success of SPI

--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -70,7 +70,9 @@ Adafruit_SPIDevice::Adafruit_SPIDevice(int8_t cspin, int8_t sckpin,
   _spi = NULL;
 }
 
-// release memory allocated in constructors
+/*!
+ *    @brief  Release memory allocated in constructors
+ */
 Adafruit_SPIDevice::~Adafruit_SPIDevice() {
   if (_spiSetting) {
     delete _spiSetting;

--- a/Adafruit_SPIDevice.h
+++ b/Adafruit_SPIDevice.h
@@ -64,6 +64,7 @@ public:
                      uint32_t freq = 1000000,
                      BitOrder dataOrder = SPI_BITORDER_MSBFIRST,
                      uint8_t dataMode = SPI_MODE0);
+  ~Adafruit_SPIDevice();
 
   bool begin(void);
   bool read(uint8_t *buffer, size_t len, uint8_t sendvalue = 0xFF);


### PR DESCRIPTION
While adding [automated testing](https://github.com/Arduino-CI/Adafruit_BusIO) to this library we discovered a memory leak. This should fix it.
