### PR TITLE
Add new SPI register type

### DIFF
--- a/Adafruit_BusIO_Register.cpp
+++ b/Adafruit_BusIO_Register.cpp
@@ -209,7 +209,7 @@ bool Adafruit_BusIO_Register::read(uint8_t *buffer, uint8_t len) {
       // the 'actual' reg addr is the second byte then
       addrbuffer[1] = (uint8_t)(_address & 0xFF);
       // the address appears to be a byte longer
-      return _spidevice->write(buffer, len, addrbuffer, _addrwidth+1);
+      return _spidevice->write_then_read(addrbuffer, _addrwidth+1, buffer, len);
     }
     if (_spiregtype == ADDRBIT8_HIGH_TOREAD) {
       addrbuffer[0] |= 0x80;

--- a/Adafruit_BusIO_Register.h
+++ b/Adafruit_BusIO_Register.h
@@ -15,13 +15,21 @@ typedef enum _Adafruit_BusIO_SPIRegType {
    */
   AD8_HIGH_TOREAD_AD7_HIGH_TOINC = 1,
 
-  ADDRBIT8_HIGH_TOWRITE = 2,
   /*!<
    * ADDRBIT8_HIGH_TOWRITE
    * When writing to a register you must actually send the value 0x80 +
    * the register address to the device. e.g. To write to the register 0x19 the
    * register value 0x99 is sent and to read 0x19 is sent.
    */
+  ADDRBIT8_HIGH_TOWRITE = 2,
+
+  /*!<
+   * ADDRESSED_OPCODE_LOWBIT_TO_WRITE
+   * Used by the MCP23S series, we send 0x40 |'rd with the opcode
+   * Then set the lowest bit to write
+   */
+  ADDRESSED_OPCODE_BIT0_LOW_TO_WRITE = 3,
+
 } Adafruit_BusIO_SPIRegType;
 
 /*!


### PR DESCRIPTION
For #47. Adds new SPI register type `ADDRESSED_OPCODE_BIT0_LOW_TO_WRITE` for use with MCP23xxx.