### PR TITLE
Avoid TwoWire mandatory initialization

### DIFF
--- a/Adafruit_BusIO.h
+++ b/Adafruit_BusIO.h
@@ -1,0 +1,9 @@
+#ifndef ADAFRUIT_BUSIO_H
+#define ADAFRUIT_BUSIO_H
+
+#include "Adafruit_BusIO_Register.h"
+#include "Adafruit_I2CDevice.h"
+#include "Adafruit_I2CRegister.h"
+#include "Adafruit_SPIDevice.h"
+
+#endif

--- a/Adafruit_I2CDevice.cpp
+++ b/Adafruit_I2CDevice.cpp
@@ -24,10 +24,15 @@ Adafruit_I2CDevice::Adafruit_I2CDevice(uint8_t addr, TwoWire *theWire) {
  *    @param  addr_detect Whether we should attempt to detect the I2C address
  * with a scan. 99% of sensors/devices don't mind but once in a while, they spaz
  * on a scan!
+ *    @param dontInitialize Whether to initialize the given TwoWire object.
  *    @return True if I2C initialized and a device with the addr found
  */
-bool Adafruit_I2CDevice::begin(bool addr_detect) {
-  _wire->begin();
+bool Adafruit_I2CDevice::begin(bool addr_detect, const bool dontInitialize) {
+  if (!dontInitialize)
+  {
+    const bool ok = _wire->begin();
+    if (!ok) return false;
+  }
   _begun = true;
 
   if (addr_detect) {

--- a/Adafruit_I2CDevice.h
+++ b/Adafruit_I2CDevice.h
@@ -8,7 +8,7 @@ class Adafruit_I2CDevice {
 public:
   Adafruit_I2CDevice(uint8_t addr, TwoWire *theWire = &Wire);
   uint8_t address(void);
-  bool begin(bool addr_detect = true);
+  bool begin(bool addr_detect = true, const bool dontInitialize = false);
   bool detected(void);
 
   bool read(uint8_t *buffer, size_t len, bool stop = true);


### PR DESCRIPTION
Hi,

this pr adds a flag to avoid the initialization of the TwoWire object.
This is required when there are many I2C devices, and, therefore, the I2C (TwoWire)
initialization should be performed only once.

As bonus, this pr adds:
* a missing check of TwoWire initialization has been added
* a missing header (Adafruit_BusIO.h) required to install this library by using arduino-cli

The changes are fully backward compatible.
