### PR TITLE
Update chunk

### DIFF
--- a/Adafruit_I2CDevice.cpp
+++ b/Adafruit_I2CDevice.cpp
@@ -77,10 +77,19 @@ bool Adafruit_I2CDevice::detected(void) {
 bool Adafruit_I2CDevice::write(const uint8_t *buffer, size_t len, bool stop,
                                const uint8_t *prefix_buffer,
                                size_t prefix_len) {
+  if ((len + prefix_len) > maxBufferSize()) {
+    // currently not guaranteed to work if more than 32 bytes!
+    // we will need to find out if some platforms have larger
+    // I2C buffer sizes :/
+#ifdef DEBUG_SERIAL
+    DEBUG_SERIAL.println(F("\tI2CDevice could not write such a large buffer"));
+#endif
+    return false;
+  }
+
   _wire->beginTransmission(_addr);
 
   // Write the prefix data (usually an address)
-  // This is required to be less than _maxBufferSize, so no need to chunkify
   if ((prefix_len != 0) && (prefix_buffer != NULL)) {
     if (_wire->write(prefix_buffer, prefix_len) != prefix_len) {
 #ifdef DEBUG_SERIAL
@@ -90,32 +99,14 @@ bool Adafruit_I2CDevice::write(const uint8_t *buffer, size_t len, bool stop,
     }
   }
 
-  // Write the data itself, chunkify if needed
-  size_t bufferSize = maxBufferSize();
-  if (bufferSize >= len) {
-    // can just write
-    if (_wire->write(buffer, len) != len) {
+  // Write the data itself
+  if (_wire->write(buffer, len) != len) {
 #ifdef DEBUG_SERIAL
-      DEBUG_SERIAL.println(F("\tI2CDevice failed to write"));
+    DEBUG_SERIAL.println(F("\tI2CDevice failed to write"));
 #endif
-      return false;
-    }
-  } else {
-    // must chunkify
-    size_t pos = 0;
-    uint8_t write_buffer[bufferSize];
-    while (pos < len) {
-      size_t write_len = len - pos > bufferSize ? bufferSize : len - pos;
-      for (size_t i = 0; i < write_len; i++)
-        write_buffer[i] = buffer[pos++];
-      if (_wire->write(write_buffer, write_len) != write_len) {
-#ifdef DEBUG_SERIAL
-        DEBUG_SERIAL.println(F("\tI2CDevice failed to write"));
-#endif
-        return false;
-      }
-    }
+    return false;
   }
+
 #ifdef DEBUG_SERIAL
 
   DEBUG_SERIAL.print(F("\tI2CWRITE @ 0x"));
@@ -146,7 +137,7 @@ bool Adafruit_I2CDevice::write(const uint8_t *buffer, size_t len, bool stop,
 
   if (_wire->endTransmission(stop) == 0) {
 #ifdef DEBUG_SERIAL
-    DEBUG_SERIAL.println("Sent!");
+    // DEBUG_SERIAL.println("Sent!");
 #endif
     return true;
   } else {
@@ -166,24 +157,15 @@ bool Adafruit_I2CDevice::write(const uint8_t *buffer, size_t len, bool stop,
  *    @return True if read was successful, otherwise false.
  */
 bool Adafruit_I2CDevice::read(uint8_t *buffer, size_t len, bool stop) {
-  size_t bufferSize = maxBufferSize();
-  if (bufferSize >= len) {
-    // can just read
-    return _read(buffer, len, stop);
-  } else {
-    // must chunkify
-    size_t pos = 0;
-    uint8_t read_buffer[bufferSize];
-    while (pos < len) {
-      size_t read_len = len - pos > bufferSize ? bufferSize : len - pos;
-      if (!_read(read_buffer, read_len, false)) {
-        return false;
-      }
-      for (size_t i = 0; i < read_len; i++)
-        buffer[pos++] = read_buffer[i];
-    }
-    return true;
+  size_t pos = 0;
+  while (pos < len) {
+    size_t read_len = len - pos > maxBufferSize() ? maxBufferSize() : len - pos;
+    bool read_stop = pos < (len - read_len) ? false : stop;
+    if (!_read(buffer + pos, read_len, read_stop))
+      return false;
+    pos += read_len;
   }
+  return true;
 }
 
 bool Adafruit_I2CDevice::_read(uint8_t *buffer, size_t len, bool stop) {

--- a/Adafruit_I2CDevice.cpp
+++ b/Adafruit_I2CDevice.cpp
@@ -159,8 +159,9 @@ bool Adafruit_I2CDevice::write(const uint8_t *buffer, size_t len, bool stop,
 bool Adafruit_I2CDevice::read(uint8_t *buffer, size_t len, bool stop) {
   size_t pos = 0;
   while (pos < len) {
-    size_t read_len = len - pos > maxBufferSize() ? maxBufferSize() : len - pos;
-    bool read_stop = pos < (len - read_len) ? false : stop;
+    size_t read_len =
+        ((len - pos) > maxBufferSize()) ? maxBufferSize() : (len - pos);
+    bool read_stop = (pos < (len - read_len)) ? false : stop;
     if (!_read(buffer + pos, read_len, read_stop))
       return false;
     pos += read_len;

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit BusIO
-version=1.9.1
+version=1.9.2
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=This is a library for abstracting away UART, I2C and SPI interfacing


### PR DESCRIPTION
- Removes chunkification from `write` and reverts back to original non-chunk code.
- Updates chunkification in `read` to work directly on buffer passed in

Tested with AMG8833 `pixel_test` [example](https://github.com/adafruit/Adafruit_AMG88xx/blob/master/examples/pixels_test/pixels_test.ino) on an UNO and Feather ESP32 for chunk cases and Qt Py M0 for non-chunk case.

### **UNO**
![Screenshot from 2021-09-27 11-25-58](https://user-images.githubusercontent.com/8755041/134966205-a026ed4d-6489-4019-87e8-5d07d0f1d659.png)

Can see the chunks on the read (gap in SCL):
![image](https://user-images.githubusercontent.com/8755041/134965938-42802c31-7151-443f-b0f8-402f2ea875e1.png)


### **Feather ESP32**
![Screenshot from 2021-09-27 11-23-21](https://user-images.githubusercontent.com/8755041/134966244-6ff37919-4924-46a6-b501-da436573e409.png)

Can see the chunks on the read (gap in SCL):
![image](https://user-images.githubusercontent.com/8755041/134965922-071dd9cd-7284-4587-ab7e-209814ff4d56.png)


### **Qt Py M0**
![Screenshot from 2021-09-27 11-34-00](https://user-images.githubusercontent.com/8755041/134966340-81926197-cada-4c0e-991b-81a9fef04331.png)

No chunks needed here:
![image](https://user-images.githubusercontent.com/8755041/134965907-80486505-c0ee-45a4-a1b7-52c6f6ce5a21.png)


