### PR TITLE
add end() to de-init i2c peripheral

### DIFF
--- a/Adafruit_I2CDevice.cpp
+++ b/Adafruit_I2CDevice.cpp
@@ -35,6 +35,12 @@ bool Adafruit_I2CDevice::begin(bool addr_detect) {
   return true;
 }
 
+void Adafruit_I2CDevice::end(void)
+{
+  _wire->end();
+  _begun = false;
+}
+
 /*!
  *    @brief  Scans I2C for the address - note will give a false-positive
  *    if there's no pullups on I2C

--- a/Adafruit_I2CDevice.cpp
+++ b/Adafruit_I2CDevice.cpp
@@ -35,6 +35,9 @@ bool Adafruit_I2CDevice::begin(bool addr_detect) {
   return true;
 }
 
+/*!
+ *    @brief  De-initialize device, turn off the Wire interface
+ */
 void Adafruit_I2CDevice::end(void) {
 #ifndef ESP8266
   // ESP8266 does not implement Wire::end()

--- a/Adafruit_I2CDevice.cpp
+++ b/Adafruit_I2CDevice.cpp
@@ -35,9 +35,12 @@ bool Adafruit_I2CDevice::begin(bool addr_detect) {
   return true;
 }
 
-void Adafruit_I2CDevice::end(void)
-{
+void Adafruit_I2CDevice::end(void) {
+#ifndef ESP8266
+  // ESP8266 does not implement Wire::end()
   _wire->end();
+#endif
+
   _begun = false;
 }
 

--- a/Adafruit_I2CDevice.h
+++ b/Adafruit_I2CDevice.h
@@ -10,6 +10,7 @@ public:
   Adafruit_I2CDevice(uint8_t addr, TwoWire *theWire = &Wire);
   uint8_t address(void);
   bool begin(bool addr_detect = true);
+  void end(void);
   bool detected(void);
 
   bool read(uint8_t *buffer, size_t len, bool stop = true);


### PR DESCRIPTION
Add end() API, part of the effort to address 
- https://github.com/adafruit/Adafruit_LTR390/issues/2 

lacking ACK cause internal error on nrf52 i2c which can only be recovered by re-init the module. This end() allow to do it in nice manner. 