### PR TITLE
Fix 32u with Wire end()

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -20,7 +20,7 @@ jobs:
       run: bash ci/actions_install.sh
 
     - name: test platforms
-      run: python3 ci/build_platform.py main_platforms zero
+      run: python3 ci/build_platform.py main_platforms zero feather32u4
 
     - name: clang
       run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r . 

--- a/Adafruit_I2CDevice.cpp
+++ b/Adafruit_I2CDevice.cpp
@@ -39,12 +39,13 @@ bool Adafruit_I2CDevice::begin(bool addr_detect) {
  *    @brief  De-initialize device, turn off the Wire interface
  */
 void Adafruit_I2CDevice::end(void) {
-#ifndef ESP8266
-  // ESP8266 does not implement Wire::end()
+  // Not all port implement Wire::end(), such as
+  // - ESP8266
+  // - AVR core without WIRE_HAS_END
+#if ! ( defined(ESP8266) || (defined(ARDUINO_ARCH_AVR) && !defined(WIRE_HAS_END)) )
   _wire->end();
-#endif
-
   _begun = false;
+#endif
 }
 
 /*!

--- a/Adafruit_I2CDevice.cpp
+++ b/Adafruit_I2CDevice.cpp
@@ -42,7 +42,11 @@ void Adafruit_I2CDevice::end(void) {
   // Not all port implement Wire::end(), such as
   // - ESP8266
   // - AVR core without WIRE_HAS_END
-#if !(defined(ESP8266) || (defined(ARDUINO_ARCH_AVR) && !defined(WIRE_HAS_END)))
+  // - ESP32: end() is implemented since 2.0.1 which is latest at the moment.
+  // Temporarily disable for now to give time for user to update.
+#if !(defined(ESP8266) ||                                                      \
+      (defined(ARDUINO_ARCH_AVR) && !defined(WIRE_HAS_END)) ||                 \
+      defined(ARDUINO_ARCH_ESP32))
   _wire->end();
   _begun = false;
 #endif

--- a/Adafruit_I2CDevice.cpp
+++ b/Adafruit_I2CDevice.cpp
@@ -42,7 +42,7 @@ void Adafruit_I2CDevice::end(void) {
   // Not all port implement Wire::end(), such as
   // - ESP8266
   // - AVR core without WIRE_HAS_END
-#if ! ( defined(ESP8266) || (defined(ARDUINO_ARCH_AVR) && !defined(WIRE_HAS_END)) )
+#if !(defined(ESP8266) || (defined(ARDUINO_ARCH_AVR) && !defined(WIRE_HAS_END)))
   _wire->end();
   _begun = false;
 #endif


### PR DESCRIPTION
- use `WIRE_HAS_END` from arch AVR to detect whether wire has end(). This will work with both avr core that implement or not the wire end()
- Update: temporarily skip end() for esp32, which only implement end() starting from 2.0.1 (currently latest), this will give time for user to update their core (will enable later on). fix #69 