### PR TITLE
Added missing Adafruit_BusIO.h required by arduino-cli

### DIFF
--- a/Adafruit_BusIO.h
+++ b/Adafruit_BusIO.h
@@ -1,0 +1,9 @@
+#ifndef ADAFRUIT_BUSIO_H
+#define ADAFRUIT_BUSIO_H
+
+#include "Adafruit_BusIO_Register.h"
+#include "Adafruit_I2CDevice.h"
+#include "Adafruit_I2CRegister.h"
+#include "Adafruit_SPIDevice.h"
+
+#endif


### PR DESCRIPTION
Hi,

this simple pr just adds the file Adafruit_BusIO.h currently required by `arduino-cli` for installation.
It could be also an empty file, but I just included the other headers.

Nothing else has been touched.

Regards