### PR TITLE
Faster hardware SPI writes on SAMD

### DIFF
--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -310,6 +310,15 @@ bool Adafruit_SPIDevice::write(uint8_t *buffer, size_t len,
       _spi->transferBytes(buffer, nullptr, len);
     }
   } else
+#elif defined(ARDUINO_ARCH_SAMD)
+  if (_spi) {
+    if (prefix_len > 0) {
+      _spi->transfer(prefix_buffer, nullptr, prefix_len);
+    }
+    if (len > 0) {
+      _spi->transfer(buffer, nullptr, len);
+    }
+  } else
 #endif
   {
     for (size_t i = 0; i < prefix_len; i++) {
@@ -412,6 +421,12 @@ bool Adafruit_SPIDevice::write_then_read(uint8_t *write_buffer,
   if (_spi) {
     if (write_len > 0) {
       _spi->transferBytes(write_buffer, nullptr, write_len);
+    }
+  } else
+#elif defined(ARDUINO_ARCH_SAMD)
+  if (_spi) {
+    if (write_len > 0) {
+      _spi->transfer(write_buffer, nullptr, write_len);
     }
   } else
 #endif

--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -310,7 +310,14 @@ bool Adafruit_SPIDevice::write(uint8_t *buffer, size_t len,
       _spi->transferBytes(buffer, nullptr, len);
     }
   } else
-#elif defined(ARDUINO_ARCH_SAMD)
+#elif defined(ARDUINO_ARCH_SAMD) && defined(_ADAFRUIT_ZERODMA_H_)
+  // The variant of transfer() used below currently only exists in the Adafruit core.
+  // It causes a build failure when building against the main Arduino SAMD core.
+  // Unfortunately there doesn't seem to be a supported #define that this code
+  // can use to tell which core it's building against. This hack
+  // (checking for the include guard that gets defined when the Adafruit core's
+  // SPI.h includes Adafruit_ZeroDMA.h) works for now, but it should be improved
+  // when possible.
   if (_spi) {
     if (prefix_len > 0) {
       _spi->transfer(prefix_buffer, nullptr, prefix_len);
@@ -423,7 +430,14 @@ bool Adafruit_SPIDevice::write_then_read(uint8_t *write_buffer,
       _spi->transferBytes(write_buffer, nullptr, write_len);
     }
   } else
-#elif defined(ARDUINO_ARCH_SAMD)
+#elif defined(ARDUINO_ARCH_SAMD) && defined(_ADAFRUIT_ZERODMA_H_)
+  // The variant of transfer() used below currently only exists in the Adafruit core.
+  // It causes a build failure when building against the main Arduino SAMD core.
+  // Unfortunately there doesn't seem to be a supported #define that this code
+  // can use to tell which core it's building against. This hack
+  // (checking for the include guard that gets defined when the Adafruit core's
+  // SPI.h includes Adafruit_ZeroDMA.h) works for now, but it should be improved
+  // when possible.
   if (_spi) {
     if (write_len > 0) {
       _spi->transfer(write_buffer, nullptr, write_len);

--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -311,13 +311,13 @@ bool Adafruit_SPIDevice::write(uint8_t *buffer, size_t len,
     }
   } else
 #elif defined(ARDUINO_ARCH_SAMD) && defined(_ADAFRUIT_ZERODMA_H_)
-  // The variant of transfer() used below currently only exists in the Adafruit core.
-  // It causes a build failure when building against the main Arduino SAMD core.
-  // Unfortunately there doesn't seem to be a supported #define that this code
-  // can use to tell which core it's building against. This hack
-  // (checking for the include guard that gets defined when the Adafruit core's
-  // SPI.h includes Adafruit_ZeroDMA.h) works for now, but it should be improved
-  // when possible.
+  // The variant of transfer() used below currently only exists in the Adafruit
+  // core. It causes a build failure when building against the main Arduino SAMD
+  // core. Unfortunately there doesn't seem to be a supported #define that this
+  // code can use to tell which core it's building against. This hack (checking
+  // for the include guard that gets defined when the Adafruit core's SPI.h
+  // includes Adafruit_ZeroDMA.h) works for now, but it should be improved when
+  // possible.
   if (_spi) {
     if (prefix_len > 0) {
       _spi->transfer(prefix_buffer, nullptr, prefix_len);
@@ -431,13 +431,13 @@ bool Adafruit_SPIDevice::write_then_read(uint8_t *write_buffer,
     }
   } else
 #elif defined(ARDUINO_ARCH_SAMD) && defined(_ADAFRUIT_ZERODMA_H_)
-  // The variant of transfer() used below currently only exists in the Adafruit core.
-  // It causes a build failure when building against the main Arduino SAMD core.
-  // Unfortunately there doesn't seem to be a supported #define that this code
-  // can use to tell which core it's building against. This hack
-  // (checking for the include guard that gets defined when the Adafruit core's
-  // SPI.h includes Adafruit_ZeroDMA.h) works for now, but it should be improved
-  // when possible.
+  // The variant of transfer() used below currently only exists in the Adafruit
+  // core. It causes a build failure when building against the main Arduino SAMD
+  // core. Unfortunately there doesn't seem to be a supported #define that this
+  // code can use to tell which core it's building against. This hack (checking
+  // for the include guard that gets defined when the Adafruit core's SPI.h
+  // includes Adafruit_ZeroDMA.h) works for now, but it should be improved when
+  // possible.
   if (_spi) {
     if (write_len > 0) {
       _spi->transfer(write_buffer, nullptr, write_len);


### PR DESCRIPTION
In the Adafruit_SPIDevice class, when running on the SAMD architecture in the hardware SPI case, use the SPIClass::transfer(txbuf, rxbuf, count, block) method when writing instead of looping over individual bytes.

This makes use of DMA and is noticeably faster.
