### PR TITLE
write method parameter const-ness

### DIFF
--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -296,7 +296,8 @@ void Adafruit_SPIDevice::endTransaction(void) {
  * writes
  */
 bool Adafruit_SPIDevice::write(const uint8_t *buffer, size_t len,
-                               const uint8_t *prefix_buffer, size_t prefix_len) {
+                               const uint8_t *prefix_buffer,
+                               size_t prefix_len) {
   if (_spi) {
     _spi->beginTransaction(*_spiSetting);
   }

--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -295,8 +295,8 @@ void Adafruit_SPIDevice::endTransaction(void) {
  *    @return Always returns true because there's no way to test success of SPI
  * writes
  */
-bool Adafruit_SPIDevice::write(uint8_t *buffer, size_t len,
-                               uint8_t *prefix_buffer, size_t prefix_len) {
+bool Adafruit_SPIDevice::write(const uint8_t *buffer, size_t len,
+                               const uint8_t *prefix_buffer, size_t prefix_len) {
   if (_spi) {
     _spi->beginTransaction(*_spiSetting);
   }
@@ -402,7 +402,7 @@ bool Adafruit_SPIDevice::read(uint8_t *buffer, size_t len, uint8_t sendvalue) {
  *    @return Always returns true because there's no way to test success of SPI
  * writes
  */
-bool Adafruit_SPIDevice::write_then_read(uint8_t *write_buffer,
+bool Adafruit_SPIDevice::write_then_read(const uint8_t *write_buffer,
                                          size_t write_len, uint8_t *read_buffer,
                                          size_t read_len, uint8_t sendvalue) {
   if (_spi) {

--- a/Adafruit_SPIDevice.h
+++ b/Adafruit_SPIDevice.h
@@ -77,9 +77,9 @@ public:
 
   bool begin(void);
   bool read(uint8_t *buffer, size_t len, uint8_t sendvalue = 0xFF);
-  bool write(uint8_t *buffer, size_t len, uint8_t *prefix_buffer = NULL,
+  bool write(const uint8_t *buffer, size_t len, const uint8_t *prefix_buffer = NULL,
              size_t prefix_len = 0);
-  bool write_then_read(uint8_t *write_buffer, size_t write_len,
+  bool write_then_read(const uint8_t *write_buffer, size_t write_len,
                        uint8_t *read_buffer, size_t read_len,
                        uint8_t sendvalue = 0xFF);
   bool write_and_read(uint8_t *buffer, size_t len);

--- a/Adafruit_SPIDevice.h
+++ b/Adafruit_SPIDevice.h
@@ -77,8 +77,8 @@ public:
 
   bool begin(void);
   bool read(uint8_t *buffer, size_t len, uint8_t sendvalue = 0xFF);
-  bool write(const uint8_t *buffer, size_t len, const uint8_t *prefix_buffer = NULL,
-             size_t prefix_len = 0);
+  bool write(const uint8_t *buffer, size_t len,
+             const uint8_t *prefix_buffer = NULL, size_t prefix_len = 0);
   bool write_then_read(const uint8_t *write_buffer, size_t write_len,
                        uint8_t *read_buffer, size_t read_len,
                        uint8_t sendvalue = 0xFF);


### PR DESCRIPTION
fix https://github.com/adafruit/Adafruit_FRAM_SPI/issues/25

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

Scope: added `const` keyword to the following two methods in the Adafruit_SPIDevice class:
`bool write(const uint8_t *buffer, size_t len, const uint8_t *prefix_buffer = NULL,
             size_t prefix_len = 0);`
`bool write_then_read(const uint8_t *write_buffer, size_t write_len,
                       uint8_t *read_buffer, size_t read_len,
                       uint8_t sendvalue = 0xFF);`

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

I was only able to test the modified code with ESP32 DevKitC (espressif) and the Adafruit SPI Non-Volatile FRAM Breakout - 64Kbit / 8KByte (MB85RS64V). This means the `else` part (i.e. non-esp32 arduino MCUs) of the following code is not tested.

https://github.com/adafruit/Adafruit_BusIO/blob/1741708a6ae80a9805f35f69ab7ed7787a252825/Adafruit_SPIDevice.cpp#L306-L323

Also, I wasn't able to run a test `write_then_read` on a mcu.


