### PR TITLE
combined read/write methods for an improvement in performance

### DIFF
--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -114,7 +114,8 @@ bool Adafruit_SPIDevice::begin(void) {
 }
 
 /*!
- *    @brief  Transfer (send/receive) one byte over hard/soft SPI
+ *    @brief  Transfer (send/receive) one byte over hard/soft SPI, without
+ * transaction management
  *    @param  buffer The buffer to send and receive at the same time
  *    @param  len    The number of bytes to transfer
  */
@@ -159,7 +160,6 @@ void Adafruit_SPIDevice::transfer(uint8_t *buffer, size_t len) {
     // Serial.print(send, HEX);
     for (uint8_t b = startbit; b != 0;
          b = (_dataOrder == SPI_BITORDER_LSBFIRST) ? b << 1 : b >> 1) {
-
       if (bitdelay_us) {
         delayMicroseconds(bitdelay_us);
       }
@@ -251,7 +251,8 @@ void Adafruit_SPIDevice::transfer(uint8_t *buffer, size_t len) {
 }
 
 /*!
- *    @brief  Transfer (send/receive) one byte over hard/soft SPI
+ *    @brief  Transfer (send/receive) one byte over hard/soft SPI, without
+ * transaction management
  *    @param  send The byte to send
  *    @return The byte received while transmitting
  */
@@ -259,6 +260,16 @@ uint8_t Adafruit_SPIDevice::transfer(uint8_t send) {
   uint8_t data = send;
   transfer(&data, 1);
   return data;
+}
+
+/*!
+ *    @brief  Assert/Deassert the CS pin if it is defined
+ */
+void Adafruit_SPIDevice::setChipSelect(int value) {
+  if (_cs == -1) {
+    return;
+  }
+  digitalWrite(_cs, value);
 }
 
 /*!
@@ -281,7 +292,26 @@ void Adafruit_SPIDevice::endTransaction(void) {
 }
 
 /*!
- *    @brief  Write a buffer or two to the SPI device.
+ *    @brief  Manually begin a transaction (calls beginTransaction if hardware
+ *            SPI) with asserting the CS pin
+ */
+void Adafruit_SPIDevice::beginTransactionWithAssertingCS(void) {
+  beginTransaction();
+  setChipSelect(LOW);
+}
+
+/*!
+ *    @brief  Manually end a transaction (calls endTransaction if hardware SPI)
+ *            with deasserting the CS pin
+ */
+void Adafruit_SPIDevice::endTransactionWithDeassertingCS(void) {
+  setChipSelect(HIGH);
+  endTransaction();
+}
+
+/*!
+ *    @brief  Write a buffer or two to the SPI device, with transaction
+ * management.
  *    @param  buffer Pointer to buffer of data to write
  *    @param  len Number of bytes from buffer to write
  *    @param  prefix_buffer Pointer to optional array of data to write before
@@ -293,34 +323,21 @@ void Adafruit_SPIDevice::endTransaction(void) {
 bool Adafruit_SPIDevice::write(const uint8_t *buffer, size_t len,
                                const uint8_t *prefix_buffer,
                                size_t prefix_len) {
-  if (_spi) {
-    _spi->beginTransaction(*_spiSetting);
-  }
+  // without a prefix_buffer to send, take the fast way and call write_and_read
+  // directly
+  if (prefix_buffer == nullptr) {
+    write_and_read(const_cast<uint8_t *>(buffer), len);
+  } else {
+    beginTransactionWithAssertingCS();
 
-  setChipSelect(LOW);
-  // do the writing
-#if defined(ARDUINO_ARCH_ESP32)
-  if (_spi) {
-    if (prefix_len > 0) {
-      _spi->transferBytes(prefix_buffer, nullptr, prefix_len);
+    if (prefix_len) {
+      transfer(const_cast<uint8_t *>(prefix_buffer), prefix_len);
     }
-    if (len > 0) {
-      _spi->transferBytes(buffer, nullptr, len);
+    if (len) {
+      transfer(const_cast<uint8_t *>(buffer), len);
     }
-  } else
-#endif
-  {
-    for (size_t i = 0; i < prefix_len; i++) {
-      transfer(prefix_buffer[i]);
-    }
-    for (size_t i = 0; i < len; i++) {
-      transfer(buffer[i]);
-    }
-  }
-  setChipSelect(HIGH);
 
-  if (_spi) {
-    _spi->endTransaction();
+    endTransactionWithDeassertingCS();
   }
 
 #ifdef DEBUG_SERIAL
@@ -347,7 +364,8 @@ bool Adafruit_SPIDevice::write(const uint8_t *buffer, size_t len,
 }
 
 /*!
- *    @brief  Read from SPI into a buffer from the SPI device.
+ *    @brief  Read from SPI into a buffer from the SPI device, with transaction
+ * management.
  *    @param  buffer Pointer to buffer of data to read into
  *    @param  len Number of bytes from buffer to read.
  *    @param  sendvalue The 8-bits of data to write when doing the data read,
@@ -356,18 +374,9 @@ bool Adafruit_SPIDevice::write(const uint8_t *buffer, size_t len,
  * writes
  */
 bool Adafruit_SPIDevice::read(uint8_t *buffer, size_t len, uint8_t sendvalue) {
-  memset(buffer, sendvalue, len); // clear out existing buffer
-  if (_spi) {
-    _spi->beginTransaction(*_spiSetting);
-  }
+  memset(buffer, sendvalue, len);
 
-  setChipSelect(LOW);
-  transfer(buffer, len);
-  setChipSelect(HIGH);
-
-  if (_spi) {
-    _spi->endTransaction();
-  }
+  write_and_read(buffer, len);
 
 #ifdef DEBUG_SERIAL
   DEBUG_SERIAL.print(F("\tSPIDevice Read: "));
@@ -386,9 +395,9 @@ bool Adafruit_SPIDevice::read(uint8_t *buffer, size_t len, uint8_t sendvalue) {
 }
 
 /*!
- *    @brief  Write some data, then read some data from SPI into another buffer.
- * The buffers can point to same/overlapping locations. This does not
- * transmit-receive at the same time!
+ *    @brief  Write some data, then read some data from SPI into another buffer,
+ * with transaction management. The buffers can point to same/overlapping
+ * locations. This does not transmit-receive at the same time!
  *    @param  write_buffer Pointer to buffer of data to write from
  *    @param  write_len Number of bytes from buffer to write.
  *    @param  read_buffer Pointer to buffer of data to read into.
@@ -401,24 +410,19 @@ bool Adafruit_SPIDevice::read(uint8_t *buffer, size_t len, uint8_t sendvalue) {
 bool Adafruit_SPIDevice::write_then_read(const uint8_t *write_buffer,
                                          size_t write_len, uint8_t *read_buffer,
                                          size_t read_len, uint8_t sendvalue) {
-  if (_spi) {
-    _spi->beginTransaction(*_spiSetting);
+  beginTransactionWithAssertingCS();
+
+  if (write_len) {
+    transfer(const_cast<uint8_t *>(write_buffer), write_len);
   }
 
-  setChipSelect(LOW);
-  // do the writing
-#if defined(ARDUINO_ARCH_ESP32)
-  if (_spi) {
-    if (write_len > 0) {
-      _spi->transferBytes(write_buffer, nullptr, write_len);
-    }
-  } else
-#endif
-  {
-    for (size_t i = 0; i < write_len; i++) {
-      transfer(write_buffer[i]);
-    }
+  if (read_len) {
+    memset(read_buffer, sendvalue, read_len);
+
+    transfer(read_buffer, read_len);
   }
+
+  endTransactionWithDeassertingCS();
 
 #ifdef DEBUG_SERIAL
   DEBUG_SERIAL.print(F("\tSPIDevice Wrote: "));
@@ -433,11 +437,6 @@ bool Adafruit_SPIDevice::write_then_read(const uint8_t *write_buffer,
   DEBUG_SERIAL.println();
 #endif
 
-  // do the reading
-  for (size_t i = 0; i < read_len; i++) {
-    read_buffer[i] = transfer(sendvalue);
-  }
-
 #ifdef DEBUG_SERIAL
   DEBUG_SERIAL.print(F("\tSPIDevice Read: "));
   for (uint16_t i = 0; i < read_len; i++) {
@@ -451,45 +450,25 @@ bool Adafruit_SPIDevice::write_then_read(const uint8_t *write_buffer,
   DEBUG_SERIAL.println();
 #endif
 
-  setChipSelect(HIGH);
-
-  if (_spi) {
-    _spi->endTransaction();
-  }
-
   return true;
 }
 
 /*!
  *    @brief  Write some data and read some data at the same time from SPI
- * into the same buffer. This is basicaly a wrapper for transfer() with
- * CS-pin and transaction management.
- * This /does/ transmit-receive at the same time!
+ * into the same buffer, with transaction management. This is basicaly a wrapper
+ * for transfer() with CS-pin and transaction management. This /does/
+ * transmit-receive at the same time!
  *    @param  buffer Pointer to buffer of data to write/read to/from
  *    @param  len Number of bytes from buffer to write/read.
  *    @return Always returns true because there's no way to test success of SPI
  * writes
  */
 bool Adafruit_SPIDevice::write_and_read(uint8_t *buffer, size_t len) {
-  if (_spi) {
-    _spi->beginTransaction(*_spiSetting);
-  }
-
-  setChipSelect(LOW);
+  beginTransactionWithAssertingCS();
   transfer(buffer, len);
-  setChipSelect(HIGH);
-
-  if (_spi) {
-    _spi->endTransaction();
-  }
+  endTransactionWithDeassertingCS();
 
   return true;
-}
-
-void Adafruit_SPIDevice::setChipSelect(int value) {
-  if (_cs == -1)
-    return;
-  digitalWrite(_cs, value);
 }
 
 #endif // SPI exists

--- a/Adafruit_SPIDevice.h
+++ b/Adafruit_SPIDevice.h
@@ -88,6 +88,8 @@ public:
   void transfer(uint8_t *buffer, size_t len);
   void beginTransaction(void);
   void endTransaction(void);
+  void beginTransactionWithAssertingCS(void);
+  void endTransactionWithDeassertingCS(void);
 
 private:
   SPIClass *_spi;


### PR DESCRIPTION
## Code
If the code doesn't run on an 8bit-AVR, the data is prepared by combining the reads and writes into one buffer, which is then transfered as one transaction on the bus. A constant decides if the buffer is allocated on the stack or from the heap, further reducing the overhead for typical small reads and writes without limiting the transactions in size. This is a tradeof between RAM and CPU: on the 'bigger' arduino platforms the CPU is a lot faster than the SPI, so using more RAM/CPU cycles and then letting the DMA do its work is the way to go.

I tested it on an ESP32 on a 10Mhz bus: The overhead for an transaction was about 0.8us/1.0us (begin/end), by combining reads and writes into a newly allocated buffer it rises to 1.0us/1.0us (begin/end). But as most of the typical transactions
are combined like getting the register contents from a chip (1 byte to send, multiple to read), combining cuts out 1.8us but adds 0.2us, which results in a net gain of 1.6us per transaction. All in all this results in a gain in typical usecases of around 15%.

## Logic analyser trace
These are two traces of the data read out of a LIS3MDL over SPI with 10Mhz data rate. The difference is clear: with these changes a transaction takes only 85% of the time as without.

### Before
![Screenshot_20220418_184113](https://user-images.githubusercontent.com/48175951/163841542-005d3f75-c26a-4b85-8b92-eedb7e39fe43.png)
### After
![Screenshot_20220418_185123](https://user-images.githubusercontent.com/48175951/163842770-667cee94-885c-4f35-94a5-415b8d798179.png)