### PR TITLE
Cleanup

### DIFF
--- a/Adafruit_BusIO_Register.cpp
+++ b/Adafruit_BusIO_Register.cpp
@@ -21,7 +21,7 @@ Adafruit_BusIO_Register::Adafruit_BusIO_Register(Adafruit_I2CDevice *i2cdevice,
                                                  uint8_t byteorder,
                                                  uint8_t address_width) {
   _i2cdevice = i2cdevice;
-  _spidevice = NULL;
+  _spidevice = nullptr;
   _addrwidth = address_width;
   _address = reg_addr;
   _byteorder = byteorder;
@@ -50,7 +50,7 @@ Adafruit_BusIO_Register::Adafruit_BusIO_Register(Adafruit_SPIDevice *spidevice,
                                                  uint8_t address_width) {
   _spidevice = spidevice;
   _spiregtype = type;
-  _i2cdevice = NULL;
+  _i2cdevice = nullptr;
   _addrwidth = address_width;
   _address = reg_addr;
   _byteorder = byteorder;
@@ -59,12 +59,12 @@ Adafruit_BusIO_Register::Adafruit_BusIO_Register(Adafruit_SPIDevice *spidevice,
 
 /*!
  *    @brief  Create a register we access over an I2C or SPI Device. This is a
- * handy function because we can pass in NULL for the unused interface, allowing
- * libraries to mass-define all the registers
- *    @param  i2cdevice The I2CDevice to use for underlying I2C access, if NULL
- * we use SPI
- *    @param  spidevice The SPIDevice to use for underlying SPI access, if NULL
- * we use I2C
+ * handy function because we can pass in nullptr for the unused interface,
+ * allowing libraries to mass-define all the registers
+ *    @param  i2cdevice The I2CDevice to use for underlying I2C access, if
+ * nullptr we use SPI
+ *    @param  spidevice The SPIDevice to use for underlying SPI access, if
+ * nullptr we use I2C
  *    @param  reg_addr The address pointer value for the I2C/SMBus/SPI register,
  * can be 8 or 16 bits
  *    @param  type     The method we use to read/write data to SPI (which is not

--- a/Adafruit_I2CDevice.cpp
+++ b/Adafruit_I2CDevice.cpp
@@ -106,7 +106,7 @@ bool Adafruit_I2CDevice::write(const uint8_t *buffer, size_t len, bool stop,
   _wire->beginTransmission(_addr);
 
   // Write the prefix data (usually an address)
-  if ((prefix_len != 0) && (prefix_buffer != NULL)) {
+  if ((prefix_len != 0) && (prefix_buffer != nullptr)) {
     if (_wire->write(prefix_buffer, prefix_len) != prefix_len) {
 #ifdef DEBUG_SERIAL
       DEBUG_SERIAL.println(F("\tI2CDevice failed to write"));
@@ -128,7 +128,7 @@ bool Adafruit_I2CDevice::write(const uint8_t *buffer, size_t len, bool stop,
   DEBUG_SERIAL.print(F("\tI2CWRITE @ 0x"));
   DEBUG_SERIAL.print(_addr, HEX);
   DEBUG_SERIAL.print(F(" :: "));
-  if ((prefix_len != 0) && (prefix_buffer != NULL)) {
+  if ((prefix_len != 0) && (prefix_buffer != nullptr)) {
     for (uint16_t i = 0; i < prefix_len; i++) {
       DEBUG_SERIAL.print(F("0x"));
       DEBUG_SERIAL.print(prefix_buffer[i], HEX);

--- a/Adafruit_I2CDevice.h
+++ b/Adafruit_I2CDevice.h
@@ -15,7 +15,7 @@ public:
 
   bool read(uint8_t *buffer, size_t len, bool stop = true);
   bool write(const uint8_t *buffer, size_t len, bool stop = true,
-             const uint8_t *prefix_buffer = NULL, size_t prefix_len = 0);
+             const uint8_t *prefix_buffer = nullptr, size_t prefix_len = 0);
   bool write_then_read(const uint8_t *write_buffer, size_t write_len,
                        uint8_t *read_buffer, size_t read_len,
                        bool stop = false);

--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -69,7 +69,7 @@ Adafruit_SPIDevice::Adafruit_SPIDevice(int8_t cspin, int8_t sckpin,
   _dataMode = dataMode;
   _begun = false;
   _spiSetting = new SPISettings(freq, dataOrder, dataMode);
-  _spi = NULL;
+  _spi = nullptr;
 }
 
 /*!
@@ -123,7 +123,7 @@ void Adafruit_SPIDevice::transfer(uint8_t *buffer, size_t len) {
     // hardware SPI is easy
 
 #if defined(SPARK)
-    _spi->transfer(buffer, buffer, len, NULL);
+    _spi->transfer(buffer, buffer, len, nullptr);
 #elif defined(STM32)
     for (size_t i = 0; i < len; i++) {
       _spi->transfer(buffer[i]);
@@ -325,7 +325,7 @@ bool Adafruit_SPIDevice::write(const uint8_t *buffer, size_t len,
 
 #ifdef DEBUG_SERIAL
   DEBUG_SERIAL.print(F("\tSPIDevice Wrote: "));
-  if ((prefix_len != 0) && (prefix_buffer != NULL)) {
+  if ((prefix_len != 0) && (prefix_buffer != nullptr)) {
     for (uint16_t i = 0; i < prefix_len; i++) {
       DEBUG_SERIAL.print(F("0x"));
       DEBUG_SERIAL.print(prefix_buffer[i], HEX);

--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -75,12 +75,7 @@ Adafruit_SPIDevice::Adafruit_SPIDevice(int8_t cspin, int8_t sckpin,
 /*!
  *    @brief  Release memory allocated in constructors
  */
-Adafruit_SPIDevice::~Adafruit_SPIDevice() {
-  if (_spiSetting) {
-    delete _spiSetting;
-    _spiSetting = nullptr;
-  }
-}
+Adafruit_SPIDevice::~Adafruit_SPIDevice() { delete _spiSetting; }
 
 /*!
  *    @brief  Initializes SPI bus and sets CS pin high

--- a/Adafruit_SPIDevice.h
+++ b/Adafruit_SPIDevice.h
@@ -78,7 +78,7 @@ public:
   bool begin(void);
   bool read(uint8_t *buffer, size_t len, uint8_t sendvalue = 0xFF);
   bool write(const uint8_t *buffer, size_t len,
-             const uint8_t *prefix_buffer = NULL, size_t prefix_len = 0);
+             const uint8_t *prefix_buffer = nullptr, size_t prefix_len = 0);
   bool write_then_read(const uint8_t *write_buffer, size_t write_len,
                        uint8_t *read_buffer, size_t read_len,
                        uint8_t sendvalue = 0xFF);


### PR DESCRIPTION
## Cleanups

These are two simple cleanups

### delete works for nullptr, no need to set a member in the destructor
and
### use the typesafe replacement nullptr instead of NULL (since C++11)