### PR TITLE
streamlined transaction management

### DIFF
--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -114,7 +114,8 @@ bool Adafruit_SPIDevice::begin(void) {
 }
 
 /*!
- *    @brief  Transfer (send/receive) one byte over hard/soft SPI
+ *    @brief  Transfer (send/receive) one byte over hard/soft SPI, without
+ * transaction management
  *    @param  buffer The buffer to send and receive at the same time
  *    @param  len    The number of bytes to transfer
  */
@@ -251,7 +252,8 @@ void Adafruit_SPIDevice::transfer(uint8_t *buffer, size_t len) {
 }
 
 /*!
- *    @brief  Transfer (send/receive) one byte over hard/soft SPI
+ *    @brief  Transfer (send/receive) one byte over hard/soft SPI, without
+ * transaction management
  *    @param  send The byte to send
  *    @return The byte received while transmitting
  */
@@ -281,7 +283,8 @@ void Adafruit_SPIDevice::endTransaction(void) {
 }
 
 /*!
- *    @brief  Write a buffer or two to the SPI device.
+ *    @brief  Write a buffer or two to the SPI device, with transaction
+ * management.
  *    @param  buffer Pointer to buffer of data to write
  *    @param  len Number of bytes from buffer to write
  *    @param  prefix_buffer Pointer to optional array of data to write before
@@ -347,7 +350,8 @@ bool Adafruit_SPIDevice::write(const uint8_t *buffer, size_t len,
 }
 
 /*!
- *    @brief  Read from SPI into a buffer from the SPI device.
+ *    @brief  Read from SPI into a buffer from the SPI device, with transaction
+ * management.
  *    @param  buffer Pointer to buffer of data to read into
  *    @param  len Number of bytes from buffer to read.
  *    @param  sendvalue The 8-bits of data to write when doing the data read,
@@ -386,9 +390,9 @@ bool Adafruit_SPIDevice::read(uint8_t *buffer, size_t len, uint8_t sendvalue) {
 }
 
 /*!
- *    @brief  Write some data, then read some data from SPI into another buffer.
- * The buffers can point to same/overlapping locations. This does not
- * transmit-receive at the same time!
+ *    @brief  Write some data, then read some data from SPI into another buffer,
+ * with transaction management. The buffers can point to same/overlapping
+ * locations. This does not transmit-receive at the same time!
  *    @param  write_buffer Pointer to buffer of data to write from
  *    @param  write_len Number of bytes from buffer to write.
  *    @param  read_buffer Pointer to buffer of data to read into.
@@ -462,9 +466,9 @@ bool Adafruit_SPIDevice::write_then_read(const uint8_t *write_buffer,
 
 /*!
  *    @brief  Write some data and read some data at the same time from SPI
- * into the same buffer. This is basicaly a wrapper for transfer() with
- * CS-pin and transaction management.
- * This /does/ transmit-receive at the same time!
+ * into the same buffer, with transaction management. This is basicaly a wrapper
+ * for transfer() with CS-pin and transaction management. This /does/
+ * transmit-receive at the same time!
  *    @param  buffer Pointer to buffer of data to write/read to/from
  *    @param  len Number of bytes from buffer to write/read.
  *    @return Always returns true because there's no way to test success of SPI

--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -388,18 +388,9 @@ bool Adafruit_SPIDevice::write(const uint8_t *buffer, size_t len,
  * writes
  */
 bool Adafruit_SPIDevice::read(uint8_t *buffer, size_t len, uint8_t sendvalue) {
-  memset(buffer, sendvalue, len); // clear out existing buffer
-  if (_spi) {
-    _spi->beginTransaction(*_spiSetting);
-  }
+  memset(buffer, sendvalue, len);
 
-  setChipSelect(LOW);
-  transfer(buffer, len);
-  setChipSelect(HIGH);
-
-  if (_spi) {
-    _spi->endTransaction();
-  }
+  write_and_read(buffer, len);
 
 #ifdef DEBUG_SERIAL
   DEBUG_SERIAL.print(F("\tSPIDevice Read: "));

--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -283,6 +283,34 @@ void Adafruit_SPIDevice::endTransaction(void) {
 }
 
 /*!
+ *    @brief  Assert/Deassert the CS pin if it is defined
+ */
+void Adafruit_SPIDevice::setChipSelect(int value) {
+  if (_cs == -1) {
+    return;
+  }
+  digitalWrite(_cs, value);
+}
+
+/*!
+ *    @brief  Manually begin a transaction (calls beginTransaction if hardware
+ *            SPI) with asserting the CS pin
+ */
+void Adafruit_SPIDevice::beginTransactionWithAssertingCS(void) {
+  beginTransaction();
+  setChipSelect(LOW);
+}
+
+/*!
+ *    @brief  Manually end a transaction (calls endTransaction if hardware SPI)
+ *            with deasserting the CS pin
+ */
+void Adafruit_SPIDevice::endTransactionWithDeassertingCS(void) {
+  setChipSelect(HIGH);
+  endTransaction();
+}
+
+/*!
  *    @brief  Write a buffer or two to the SPI device, with transaction
  * management.
  *    @param  buffer Pointer to buffer of data to write
@@ -488,12 +516,6 @@ bool Adafruit_SPIDevice::write_and_read(uint8_t *buffer, size_t len) {
   }
 
   return true;
-}
-
-void Adafruit_SPIDevice::setChipSelect(int value) {
-  if (_cs == -1)
-    return;
-  digitalWrite(_cs, value);
 }
 
 #endif // SPI exists

--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -465,17 +465,9 @@ bool Adafruit_SPIDevice::write_then_read(const uint8_t *write_buffer,
  * writes
  */
 bool Adafruit_SPIDevice::write_and_read(uint8_t *buffer, size_t len) {
-  if (_spi) {
-    _spi->beginTransaction(*_spiSetting);
-  }
-
-  setChipSelect(LOW);
+  beginTransactionWithAssertingCS();
   transfer(buffer, len);
-  setChipSelect(HIGH);
-
-  if (_spi) {
-    _spi->endTransaction();
-  }
+  endTransactionWithDeassertingCS();
 
   return true;
 }

--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -160,7 +160,6 @@ void Adafruit_SPIDevice::transfer(uint8_t *buffer, size_t len) {
     // Serial.print(send, HEX);
     for (uint8_t b = startbit; b != 0;
          b = (_dataOrder == SPI_BITORDER_LSBFIRST) ? b << 1 : b >> 1) {
-
       if (bitdelay_us) {
         delayMicroseconds(bitdelay_us);
       }

--- a/Adafruit_SPIDevice.h
+++ b/Adafruit_SPIDevice.h
@@ -88,6 +88,8 @@ public:
   void transfer(uint8_t *buffer, size_t len);
   void beginTransaction(void);
   void endTransaction(void);
+  void beginTransactionWithAssertingCS(void);
+  void endTransactionWithDeassertingCS(void);
 
 private:
   SPIClass *_spi;


### PR DESCRIPTION
## Code
These changes streamline the transaction management. It reuses already existing methods and lowers the amount of duplicated code. 

## Documentation
It also makes the documentation more precise by adding if the method does transaction management or not.

## Performance
As this code also removes the loop for individually reading/writing the bytes from the bus and replaces it with a call to the respective member, there is an substantial performance gain on platforms with multithreading and/or DMA. These results are measured on an ESP32 feather with 10MHz bus rate, which results in a gain of about 50% in typical use cases.

Consider accepting #88 to remove the wait time between writing and reading.
### Before
![Screenshot_20220418_184353](https://user-images.githubusercontent.com/48175951/163841767-1039f8ac-8f7f-4ab2-aa6b-141d3852fae9.png)
### After
![Screenshot_20220418_184113](https://user-images.githubusercontent.com/48175951/163841542-005d3f75-c26a-4b85-8b92-eedb7e39fe43.png)