### PR TITLE
T4.x - Software SPI - don't use FAST_PINIO

### DIFF
--- a/Adafruit_SPIDevice.h
+++ b/Adafruit_SPIDevice.h
@@ -39,7 +39,19 @@ typedef enum _BitOrder {
 typedef BitOrder BusIOBitOrder;
 #endif
 
-#if defined(__AVR__) || defined(TEENSYDUINO)
+#if defined(__IMXRT1062__) // Teensy 4.x
+// *Warning* I disabled the usage of FAST_PINIO as the set/clear operations
+// used in the cpp file are not atomic and can effect multiple IO pins
+// and if an interrupt happens in between the time the code reads the register
+//  and writes out the updated value, that changes one or more other IO pins
+// on that same IO port, those change will be clobbered when the updated
+// values are written back.  A fast version can be implemented that uses the
+// ports set and clear registers which are atomic.
+// typedef volatile uint32_t BusIO_PortReg;
+// typedef uint32_t BusIO_PortMask;
+//#define BUSIO_USE_FAST_PINIO
+
+#elif defined(__AVR__) || defined(TEENSYDUINO)
 typedef volatile uint8_t BusIO_PortReg;
 typedef uint8_t BusIO_PortMask;
 #define BUSIO_USE_FAST_PINIO


### PR DESCRIPTION
The original problem was that the code defined the registers and mask as 8 bits, when the T4.x ones are 32 bits.  So it only worked on a subset of pins.

So first fix would be to simply define these values as 32 bits.  But doing so leaves you code at risk as the Set/Clear code in this library is not atomic,
Example: *clkPort |= clkPinMask;

So if something happens in the small time window after the time the register is retrieved and then manipulated and written back, such as an interrupt.
Or maybe if other hardware is driving the pin.  These changes would be
clobbered by the above code.

Not sure how many other boards (if any) may be hit by the same issue.

It is not an issue with T3.x as the Teensy code uses the M3/M4 bitband support, so for each pin there is a unique memory address for it and these operations are atomic.

Note: the Arm M7 does not support bitbands.  However  in these caseAtomic code can be written for the T4.x by instead using the DR register of the IO port, you use the DR_SET, DR_CLEAR, DR_TOGGLE registers instead which do as the names imply
the do that operation only those pins who have a 1 bit set to the value...

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.

Note this is to resolve: https://github.com/adafruit/Adafruit_ICM20X/issues/16

