### PR TITLE
manually handle AVR i2c setspeed to handle slow clocks

### DIFF
--- a/Adafruit_I2CDevice.cpp
+++ b/Adafruit_I2CDevice.cpp
@@ -280,13 +280,16 @@ bool Adafruit_I2CDevice::setSpeed(uint32_t desiredclk) {
     TWSR = 0x3;
   }
 #ifdef DEBUG_SERIAL
-  Serial.print(F("TWSR prescaler = ")); Serial.println(prescaler);
-  Serial.print(F("TWBR = ")); Serial.println(atwbr);
+  Serial.print(F("TWSR prescaler = "));
+  Serial.println(prescaler);
+  Serial.print(F("TWBR = "));
+  Serial.println(atwbr);
 #endif
   TWBR = atwbr;
   return true;
 
-#elif (ARDUINO >= 157) && !defined(ARDUINO_STM32_FEATHER) && !defined(TinyWireM_h)
+#elif (ARDUINO >= 157) && !defined(ARDUINO_STM32_FEATHER) &&                   \
+    !defined(TinyWireM_h)
   _wire->setClock(desiredclk);
   return true;
 

--- a/Adafruit_I2CDevice.cpp
+++ b/Adafruit_I2CDevice.cpp
@@ -259,9 +259,37 @@ uint8_t Adafruit_I2CDevice::address(void) { return _addr; }
  *    Not necessarily that the speed was achieved!
  */
 bool Adafruit_I2CDevice::setSpeed(uint32_t desiredclk) {
-#if (ARDUINO >= 157) && !defined(ARDUINO_STM32_FEATHER) && !defined(TinyWireM_h)
+#if defined(__AVR__) // fix arduino core set clock
+  // calculate TWBR correctly
+  uint8_t prescaler = 1;
+  uint32_t atwbr = ((F_CPU / desiredclk) - 16) / 2;
+  if (atwbr <= 255) {
+    prescaler = 1;
+    TWSR = 0x0;
+  } else if (atwbr <= 1020) {
+    atwbr /= 4;
+    prescaler = 4;
+    TWSR = 0x1;
+  } else if (atwbr <= 4080) {
+    atwbr /= 16;
+    prescaler = 16;
+    TWSR = 0x2;
+  } else if (atwbr <= 16320) {
+    atwbr /= 64;
+    prescaler = 64;
+    TWSR = 0x3;
+  }
+#ifdef DEBUG_SERIAL
+  Serial.print(F("TWSR prescaler = ")); Serial.println(prescaler);
+  Serial.print(F("TWBR = ")); Serial.println(atwbr);
+#endif
+  TWBR = atwbr;
+  return true;
+
+#elif (ARDUINO >= 157) && !defined(ARDUINO_STM32_FEATHER) && !defined(TinyWireM_h)
   _wire->setClock(desiredclk);
   return true;
+
 #else
   (void)desiredclk;
   return false;


### PR DESCRIPTION
prescaler is not calculated here https://github.com/arduino/ArduinoCore-avr/blob/master/libraries/Wire/src/utility/twi.c#L139 which means we cannot get below 30.5mhz!

cc @RobTillaart  this fixes up AGS02MA behavior