### PR TITLE
Refactor for better SW SPI only support

### DIFF
--- a/Adafruit_SPIDevice.h
+++ b/Adafruit_SPIDevice.h
@@ -5,8 +5,14 @@
 
 #if !defined(SPI_INTERFACES_COUNT) ||                                          \
     (defined(SPI_INTERFACES_COUNT) && (SPI_INTERFACES_COUNT > 0))
-
+// HW SPI available
 #include <SPI.h>
+#define BUSIO_HAS_HW_SPI
+#else
+// SW SPI ONLY
+enum { SPI_MODE0, SPI_MODE1, SPI_MODE2, _SPI_MODE4 };
+typedef uint8_t SPIClass;
+#endif
 
 // some modern SPI definitions don't have BitOrder enum
 #if (defined(__AVR__) && !defined(ARDUINO_ARCH_MEGAAVR)) ||                    \
@@ -77,10 +83,15 @@ typedef uint32_t BusIO_PortMask;
 /**! The class which defines how we will talk to this device over SPI **/
 class Adafruit_SPIDevice {
 public:
+#ifdef BUSIO_HAS_HW_SPI
   Adafruit_SPIDevice(int8_t cspin, uint32_t freq = 1000000,
                      BusIOBitOrder dataOrder = SPI_BITORDER_MSBFIRST,
                      uint8_t dataMode = SPI_MODE0, SPIClass *theSPI = &SPI);
-
+#else
+  Adafruit_SPIDevice(int8_t cspin, uint32_t freq = 1000000,
+                     BusIOBitOrder dataOrder = SPI_BITORDER_MSBFIRST,
+                     uint8_t dataMode = SPI_MODE0, SPIClass *theSPI = nullptr);
+#endif
   Adafruit_SPIDevice(int8_t cspin, int8_t sck, int8_t miso, int8_t mosi,
                      uint32_t freq = 1000000,
                      BusIOBitOrder dataOrder = SPI_BITORDER_MSBFIRST,
@@ -104,8 +115,13 @@ public:
   void endTransactionWithDeassertingCS();
 
 private:
+#ifdef BUSIO_HAS_HW_SPI
   SPIClass *_spi;
   SPISettings *_spiSetting;
+#else
+  uint8_t *_spi = nullptr;
+  uint8_t *_spiSetting = nullptr;
+#endif
   uint32_t _freq;
   BusIOBitOrder _dataOrder;
   uint8_t _dataMode;
@@ -119,5 +135,4 @@ private:
   bool _begun;
 };
 
-#endif // has SPI defined
 #endif // Adafruit_SPIDevice_h


### PR DESCRIPTION
For #81, but also motivated by:
https://github.com/adafruit/Adafruit_DotStar/issues/50

Essentially just some preproc foo.

This simple DotStar example runs as expected on a Trinket 3V ([PID 1500](https://www.adafruit.com/product/1500)).
```cpp
#include <Adafruit_DotStar.h>

#define NUMPIXELS  10
#define DATAPIN    2
#define CLOCKPIN   1
Adafruit_DotStar strip(NUMPIXELS, DATAPIN, CLOCKPIN, DOTSTAR_BGR);

void setup() {
  strip.begin();
  strip.fill(0xADAF00);
  strip.show();
}

void loop() {
}
```

And testing a BME280 wired to hardware SPI on a QT PY M0 still works (didn't break HW SPI check):
```
BME280 test
-- Default Test --

Temperature = 24.99 °C
Pressure = 1006.83 hPa
Approx. Altitude = 53.57 m
Humidity = 57.60 %

Temperature = 25.24 °C
Pressure = 1006.87 hPa
Approx. Altitude = 53.28 m
Humidity = 57.52 %

Temperature = 25.28 °C
Pressure = 1006.85 hPa
Approx. Altitude = 53.40 m
Humidity = 57.43 %
```