### PR TITLE
If there are no global instances defined, don't provide default &Seri…

### DIFF
--- a/Adafruit_BusIO_Register.h
+++ b/Adafruit_BusIO_Register.h
@@ -71,8 +71,13 @@ public:
   void setAddress(uint16_t address);
   void setAddressWidth(uint16_t address_width);
 
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_SERIAL)
   void print(Stream *s = &Serial);
   void println(Stream *s = &Serial);
+#elif
+  void print(Stream *s);
+  void println(Stream *s);
+#endif
 
 private:
   Adafruit_I2CDevice *_i2cdevice;


### PR DESCRIPTION
This is a fix to issue #111 where if `HardwareSerial Serial` is not defined, `Adafruit_BusIO_Register.h` will not be able to find `Serial` and cause compilation to fail.

The change only affects the scope where either `NO_GLOBAL_INSTANCES` or `NO_GLOBAL_SERIAL` is defined, which is the case where it was failing to compile anyway. In all other cases, the change has no impact. If a dependent is requiring the default argument, then the dependent will not compile anyway if there is no global serial.