### PR TITLE
Add support for the ESP8266 microcontroller

### DIFF
--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -124,7 +124,7 @@ void Adafruit_SPIDevice::transfer(uint8_t *buffer, size_t len) {
 
 #if defined(SPARK)
     _spi->transfer(buffer, buffer, len, nullptr);
-#elif defined(STM32)
+#elif defined(STM32) || defined(ESP8266)
     for (size_t i = 0; i < len; i++) {
       _spi->transfer(buffer[i]);
     }


### PR DESCRIPTION
Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**
This patch adds support for the ESP8266 microcontroller, as well as the ESP8285 (because they both use the same platform #defines).

- **Describe any known limitations with your change.**
- Um, only affects ESP8266 and ESP8285 chips?

- **Please run any tests or examples that can exercise your modified code.**
- Has been tested successfully on a few ESP8266 boards with a small variety of I2C devices. Somehow, this architecture does not support sending the whole buffer by reference and length like Arduino-compatible ones do, so it's using the same loop as the STM32 microcontroller architecture.