### PR TITLE
fix: Set the maximum SPI SW frequency to 250 KHz

### DIFF
--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -41,7 +41,8 @@ Adafruit_SPIDevice::Adafruit_SPIDevice(int8_t cspin, uint32_t freq,
  * used
  *    @param  mosipin The arduino pin number to use for MOSI, set to -1 if not
  * used
- *    @param  freq The SPI clock frequency to use, defaults to 1MHz
+ *    @param  freq The SPI clock frequency to use, defaults to 1MHz, limited to
+ * 250KHz if SW SPI
  *    @param  dataOrder The SPI data order to use for bits within each byte,
  * defaults to SPI_BITORDER_MSBFIRST
  *    @param  dataMode The SPI mode to use, defaults to SPI_MODE0
@@ -70,7 +71,12 @@ Adafruit_SPIDevice::Adafruit_SPIDevice(int8_t cspin, int8_t sckpin,
   clkPinMask = digitalPinToBitMask(sckpin);
 #endif
 
-  _freq = freq;
+  if (freq > SW_SPI_MAX_FREQ) {
+    _freq = SW_SPI_MAX_FREQ;
+  } else {
+    _freq = freq;
+  }
+
   _dataOrder = dataOrder;
   _dataMode = dataMode;
   _begun = false;

--- a/Adafruit_SPIDevice.h
+++ b/Adafruit_SPIDevice.h
@@ -3,6 +3,8 @@
 
 #include <Arduino.h>
 
+#define SW_SPI_MAX_FREQ (250000)
+
 #if !defined(SPI_INTERFACES_COUNT) ||                                          \
     (defined(SPI_INTERFACES_COUNT) && (SPI_INTERFACES_COUNT > 0))
 // HW SPI available


### PR DESCRIPTION
The scope of my changes :

When using the software SPI mode, the function `delayMicroseconds` is manually called to reproduce the leading and the trailling edge of the clock.

If you read `void Adafruit_SPIDevice::transfer(uint8_t *buffer, size_t len)`, at the line 167, we calculate how many micro seconds we have to wait before setting the clock from high to low. (`uint8_t bitdelay_us = (1000000 / _freq) / 2;`)

The variable that hold this time in micro seconds is a uint8_t.
With a frequency of 1Mhz (1000000 us), the result of the eqution is 0.5 which is stored as 0 in a uint8_t.

So, when we call the `delayMicroseconds` function, we give `0` as value, resulting in no delay from clock high to low (there is some delay in fact but not enough).

The minimal frequency that result in only one micro second is 500 KHz (1000000/500000/2).
But in software mode, this delay (500 KHz) is too low to be reliable.
The minimal delay that works is 2 micro seconds. Which result in a frequency of 250 KHz.

Theses modifications limit the software SPI frequency to 250 KHz. The hardware SPI in kept untouched.

I cannot figure out how the external projects that use the software SPI are functionnal. In fact, we found a lot of users that complain that this mode is not functional.

I tested these modifications with an NFC reader in SW SPI mode with success.