### PR TITLE
By adding two macros all Infineons XMC MCUs are now able to use the l…

### DIFF
--- a/Adafruit_SPIDevice.h
+++ b/Adafruit_SPIDevice.h
@@ -22,7 +22,7 @@ typedef uint8_t SPIClass;
     defined(ARDUINO_AVR_ATmega4808) || defined(ARDUINO_AVR_ATmega3209) ||      \
     defined(ARDUINO_AVR_ATmega3208) || defined(ARDUINO_AVR_ATmega1609) ||      \
     defined(ARDUINO_AVR_ATmega1608) || defined(ARDUINO_AVR_ATmega809) ||       \
-    defined(ARDUINO_AVR_ATmega808) || defined(ARDUINO_ARCH_ARC32)              \
+    defined(ARDUINO_AVR_ATmega808) || defined(ARDUINO_ARCH_ARC32) ||           \
     defined(ARDUINO_ARCH_XMC)
 
 typedef enum _BitOrder {

--- a/Adafruit_SPIDevice.h
+++ b/Adafruit_SPIDevice.h
@@ -22,7 +22,8 @@ typedef uint8_t SPIClass;
     defined(ARDUINO_AVR_ATmega4808) || defined(ARDUINO_AVR_ATmega3209) ||      \
     defined(ARDUINO_AVR_ATmega3208) || defined(ARDUINO_AVR_ATmega1609) ||      \
     defined(ARDUINO_AVR_ATmega1608) || defined(ARDUINO_AVR_ATmega809) ||       \
-    defined(ARDUINO_AVR_ATmega808) || defined(ARDUINO_ARCH_ARC32)
+    defined(ARDUINO_AVR_ATmega808) || defined(ARDUINO_ARCH_ARC32)              \
+    defined(ARDUINO_ARCH_XMC)
 
 typedef enum _BitOrder {
   SPI_BITORDER_MSBFIRST = MSBFIRST,
@@ -56,6 +57,9 @@ typedef BitOrder BusIOBitOrder;
 // typedef volatile uint32_t BusIO_PortReg;
 // typedef uint32_t BusIO_PortMask;
 //#define BUSIO_USE_FAST_PINIO
+
+#elif defined(ARDUINO_ARCH_XMC)
+#undef BUSIO_USE_FAST_PINIO
 
 #elif defined(__AVR__) || defined(TEENSYDUINO)
 typedef volatile uint8_t BusIO_PortReg;


### PR DESCRIPTION
This change allows the use of Infineon XMC MCUs XMC2GO, XM1100 BootKit, XMC1300 BootKit, XMC1400 Kit For Arduino, XMC4200 Platform 2Go, XMC4400 Platform 2G and the XMC4700 Relax Kit to use the Adafruit_BusIO and Adafruit libraries based on this like the Adafuit NeoPixel and NeoMatrix libraries.

The change only includes two macro definitions for SPI settings to extend the use on ARDUINO_ARCH_XMC compatible boards,
so there is nointerference to other MCUs and there is no additional or changed code.

The purpose of this change was to enable our [Infineon Pride Wafer](https://www.hackster.io/Infineon_Team/infineon-pride-wafer-how-to-drive-4864-leds-with-one-gpio-a0b8d8) as shown together with the Adafruit NeoMatrix, but it should enable Infineon XMC MCUs in all projects which use PSI and this library.
