### PR TITLE
Remove volatile compound assignments

### DIFF
--- a/Adafruit_SPIDevice.cpp
+++ b/Adafruit_SPIDevice.cpp
@@ -183,9 +183,9 @@ void Adafruit_SPIDevice::transfer(uint8_t *buffer, size_t len) {
         if ((_mosi != -1) && (lastmosi != towrite)) {
 #ifdef BUSIO_USE_FAST_PINIO
           if (towrite)
-            *mosiPort |= mosiPinMask;
+            *mosiPort = *mosiPort | mosiPinMask;
           else
-            *mosiPort &= ~mosiPinMask;
+            *mosiPort = *mosiPort & ~mosiPinMask;
 #else
           digitalWrite(_mosi, towrite);
 #endif
@@ -193,7 +193,7 @@ void Adafruit_SPIDevice::transfer(uint8_t *buffer, size_t len) {
         }
 
 #ifdef BUSIO_USE_FAST_PINIO
-        *clkPort |= clkPinMask; // Clock high
+        *clkPort = *clkPort | clkPinMask; // Clock high
 #else
         digitalWrite(_sck, HIGH);
 #endif
@@ -213,14 +213,14 @@ void Adafruit_SPIDevice::transfer(uint8_t *buffer, size_t len) {
         }
 
 #ifdef BUSIO_USE_FAST_PINIO
-        *clkPort &= ~clkPinMask; // Clock low
+        *clkPort = *clkPort & ~clkPinMask; // Clock low
 #else
         digitalWrite(_sck, LOW);
 #endif
       } else { // if (_dataMode == SPI_MODE1 || _dataMode == SPI_MODE3)
 
 #ifdef BUSIO_USE_FAST_PINIO
-        *clkPort |= clkPinMask; // Clock high
+        *clkPort = *clkPort | clkPinMask; // Clock high
 #else
         digitalWrite(_sck, HIGH);
 #endif
@@ -232,16 +232,16 @@ void Adafruit_SPIDevice::transfer(uint8_t *buffer, size_t len) {
         if (_mosi != -1) {
 #ifdef BUSIO_USE_FAST_PINIO
           if (send & b)
-            *mosiPort |= mosiPinMask;
+            *mosiPort = *mosiPort | mosiPinMask;
           else
-            *mosiPort &= ~mosiPinMask;
+            *mosiPort = *mosiPort & ~mosiPinMask;
 #else
           digitalWrite(_mosi, send & b);
 #endif
         }
 
 #ifdef BUSIO_USE_FAST_PINIO
-        *clkPort &= ~clkPinMask; // Clock low
+        *clkPort = *clkPort & ~clkPinMask; // Clock low
 #else
         digitalWrite(_sck, LOW);
 #endif


### PR DESCRIPTION
Simple change to replace compound assignments being done with `volatile` variables to non-compound form.

This is being done to keep up with changes in C++ w.r.t. `volatile` variable usage which can lead to compilation warns.

Here's a typical warn message for ref:
```cpp
   /home/runner/Arduino/libraries/Adafruit_BusIO/Adafruit_SPIDevice.cpp:186:23: warning: compound assignment with 'volatile'-qualified left operand is deprecated [-Wvolatile]
    186 |             *mosiPort |= mosiPinMask;
        |             ~~~~~~~~~~^~~~~~~~~~~~~~
```