### PR TITLE
feat: adds SHIFT_ADDR_2BITS_LEFT option

### DIFF
--- a/Adafruit_BusIO_Register.cpp
+++ b/Adafruit_BusIO_Register.cpp
@@ -228,6 +228,10 @@ bool Adafruit_BusIO_Register::read(uint8_t *buffer, uint8_t len) {
     if (_spiregtype == AD8_HIGH_TOREAD_AD7_HIGH_TOINC) {
       addrbuffer[0] |= 0x80 | 0x40;
     }
+    if (_spiregtype == SHIFT_ADDR_2BITS_LEFT) {
+      addrbuffer[0] == addrbuffer[0] << 2;
+    }
+	
     return _spidevice->write_then_read(addrbuffer, _addrwidth, buffer, len);
   }
   return false;

--- a/Adafruit_BusIO_Register.h
+++ b/Adafruit_BusIO_Register.h
@@ -34,6 +34,13 @@ typedef enum _Adafruit_BusIO_SPIRegType {
    */
   ADDRESSED_OPCODE_BIT0_LOW_TO_WRITE = 3,
 
+  /*!<
+   * SHIFT_ADDR_2BITS_LEFT
+   * Used by the MLX90395 in SPI mode
+   * Address to be read will be shifted left by two bits
+   */
+  SHIFT_ADDR_2BITS_LEFT = 4,
+
 } Adafruit_BusIO_SPIRegType;
 
 /*!


### PR DESCRIPTION
adds `SHIFT_ADDR_2BITS_LEFT` to `Adafruit_BusIO_SPIRegType` to cater e.g. MLX90395 in SPI mode.
