### PR TITLE
Add compatibility with Silicon Labs Arduino boards

### DIFF
--- a/Adafruit_SPIDevice.h
+++ b/Adafruit_SPIDevice.h
@@ -23,7 +23,7 @@ typedef uint8_t SPIClass;
     defined(ARDUINO_AVR_ATmega3208) || defined(ARDUINO_AVR_ATmega1609) ||      \
     defined(ARDUINO_AVR_ATmega1608) || defined(ARDUINO_AVR_ATmega809) ||       \
     defined(ARDUINO_AVR_ATmega808) || defined(ARDUINO_ARCH_ARC32) ||           \
-    defined(ARDUINO_ARCH_XMC)
+    defined(ARDUINO_ARCH_XMC) || defined(ARDUINO_SILABS)
 
 typedef enum _BitOrder {
   SPI_BITORDER_MSBFIRST = MSBFIRST,
@@ -73,7 +73,8 @@ typedef uint32_t BusIO_PortMask;
 #define BUSIO_USE_FAST_PINIO
 
 #elif (defined(__arm__) || defined(ARDUINO_FEATHER52)) &&                      \
-    !defined(ARDUINO_ARCH_MBED) && !defined(ARDUINO_ARCH_RP2040)
+    !defined(ARDUINO_ARCH_MBED) && !defined(ARDUINO_ARCH_RP2040) &&            \
+    !defined(ARDUINO_SILABS)
 typedef volatile uint32_t BusIO_PortReg;
 typedef uint32_t BusIO_PortMask;
 #if !defined(__ASR6501__) && !defined(__ASR6502__)


### PR DESCRIPTION
Hey! We at Silabs recently released Arduino support for a number of our boards: https://github.com/SiliconLabs/arduino
This PR makes your BusIO library compatible with Silicon Labs Arduino boards by adding the core specific macro definitions.

**Limitations:** none
**Tests:** tested on 4 different Silicon Labs boards with an ILI9341 and an ST7735 display. Also tested with a Nano 33 BLE to ensure that there's no regression.

Let me know if there's any change needed or if you need more info on something!
All the best from your friends at Silicon Labs!

