### PR TITLE
Add compatibility with Arduino R4 boards

### DIFF
--- a/Adafruit_SPIDevice.h
+++ b/Adafruit_SPIDevice.h
@@ -74,7 +74,8 @@ typedef uint32_t BusIO_PortMask;
 
 #elif (defined(__arm__) || defined(ARDUINO_FEATHER52)) &&                      \
     !defined(ARDUINO_ARCH_MBED) && !defined(ARDUINO_ARCH_RP2040) &&            \
-    !defined(ARDUINO_SILABS)
+    !defined(ARDUINO_SILABS) &&                                                \
+    !defined(ARDUINO_UNOR4_MINIMA) && !defined(ARDUINO_UNOR4_WIFI)
 typedef volatile uint32_t BusIO_PortReg;
 typedef uint32_t BusIO_PortMask;
 #if !defined(__ASR6501__) && !defined(__ASR6502__)

--- a/Adafruit_SPIDevice.h
+++ b/Adafruit_SPIDevice.h
@@ -74,8 +74,8 @@ typedef uint32_t BusIO_PortMask;
 
 #elif (defined(__arm__) || defined(ARDUINO_FEATHER52)) &&                      \
     !defined(ARDUINO_ARCH_MBED) && !defined(ARDUINO_ARCH_RP2040) &&            \
-    !defined(ARDUINO_SILABS) &&                                                \
-    !defined(ARDUINO_UNOR4_MINIMA) && !defined(ARDUINO_UNOR4_WIFI)
+    !defined(ARDUINO_SILABS) && !defined(ARDUINO_UNOR4_MINIMA) &&              \
+    !defined(ARDUINO_UNOR4_WIFI)
 typedef volatile uint32_t BusIO_PortReg;
 typedef uint32_t BusIO_PortMask;
 #if !defined(__ASR6501__) && !defined(__ASR6502__)


### PR DESCRIPTION
After scratching my head about why my new 2.13" Monochrome eInk / ePaper Display
wasn't working with the Uno R4 after working perfectly with an R3, I added
ARDUINO_UNOR4_MINIMA and ARDUINO_UNOR4_WIFI to the list of boards
in Adafruit_SPIDevice.h that don't support BUSIO_USE_FAST_PINIO.

No limitations that I'm aware of.

Tested with some of the examples in Adafruit_EPD as well as my own code and it seems
stable.
