### PR TITLE
Fix compatibility with Silicon Labs boards

### DIFF
--- a/Adafruit_SPIDevice.h
+++ b/Adafruit_SPIDevice.h
@@ -23,7 +23,7 @@ typedef uint8_t SPIClass;
     defined(ARDUINO_AVR_ATmega3208) || defined(ARDUINO_AVR_ATmega1609) ||      \
     defined(ARDUINO_AVR_ATmega1608) || defined(ARDUINO_AVR_ATmega809) ||       \
     defined(ARDUINO_AVR_ATmega808) || defined(ARDUINO_ARCH_ARC32) ||           \
-    defined(ARDUINO_ARCH_XMC) || defined(ARDUINO_SILABS)
+    defined(ARDUINO_ARCH_XMC)
 
 typedef enum _BitOrder {
   SPI_BITORDER_MSBFIRST = MSBFIRST,


### PR DESCRIPTION
Hey! We updated the Silicon Labs core to be based on Arduino-CoreAPI - which broke compatibility with Adafruit BusIO.
This PR makes the core compatible again. We now have a native definition for `BitOrder` thanks to the CoreAPI, so a now unnecessary macro check has been removed.

**Limitations:** none
**Tests:** tested on a few different Silicon Labs / Arduino boards with an ILI9341 and an ST7735 display

Let me know if there's any change needed or if you need more info on something!
All the best from your friends at Silicon Labs!