### PR TITLE
fixed HEX print

### DIFF
--- a/Adafruit_I2CDevice.cpp
+++ b/Adafruit_I2CDevice.cpp
@@ -69,7 +69,7 @@ bool Adafruit_I2CDevice::detected(void) {
   _wire->beginTransmission(_addr);
 #ifdef DEBUG_SERIAL
   DEBUG_SERIAL.print(F("Address 0x"));
-  DEBUG_SERIAL.print(_addr);
+  DEBUG_SERIAL.print(_addr, HEX);
 #endif
   if (_wire->endTransmission() == 0) {
 #ifdef DEBUG_SERIAL


### PR DESCRIPTION
debug serial data was printing in decimal, when it should have been hex (or alternatively, the "0x" prefix should be removed)

before:
`Address 0x44 Not detected`
after
`Address 0x2C Not detected`