### PR TITLE
Patch for GIGA I2C quirk

### DIFF
--- a/Adafruit_I2CDevice.cpp
+++ b/Adafruit_I2CDevice.cpp
@@ -71,6 +71,9 @@ bool Adafruit_I2CDevice::detected(void) {
   DEBUG_SERIAL.print(F("Address 0x"));
   DEBUG_SERIAL.print(_addr);
 #endif
+#ifdef ARDUINO_ARCH_MBED
+  _wire->write(0);  // forces a write request instead of a read
+#endif
   if (_wire->endTransmission() == 0) {
 #ifdef DEBUG_SERIAL
     DEBUG_SERIAL.println(F(" Detected"));

--- a/Adafruit_I2CDevice.cpp
+++ b/Adafruit_I2CDevice.cpp
@@ -72,7 +72,7 @@ bool Adafruit_I2CDevice::detected(void) {
   DEBUG_SERIAL.print(_addr);
 #endif
 #ifdef ARDUINO_ARCH_MBED
-  _wire->write(0);  // forces a write request instead of a read
+  _wire->write(0); // forces a write request instead of a read
 #endif
   if (_wire->endTransmission() == 0) {
 #ifdef DEBUG_SERIAL


### PR DESCRIPTION
This is a simple patch to get around this issue from the Arduino mbed OS core used by the GIGA R1:
https://github.com/arduino/ArduinoCore-mbed/issues/414

Some devices will NACK the read attempt, which is equivalent to "not found".

This patch tricks the BSP logic and forces it to use a write request instead of a read request.

Example test case GIGA R1 connected to an Adafruit Arcade 1x4 Button breakout and running the example from Learn guide:
https://learn.adafruit.com/adafruit-led-arcade-button-qt/arduino

**BEFORE**
![Screenshot from 2024-10-24 14-24-19](https://github.com/user-attachments/assets/9f78cfc1-5f14-4103-9d86-79b786bed5d7)


**AFTER**
![Screenshot from 2024-10-24 14-24-51](https://github.com/user-attachments/assets/3418d763-2f69-42d6-af3b-3ffad7f4c854)

Thanks to @silvan2468 for suggesting this fix here:
https://github.com/adafruit/Adafruit_Seesaw/issues/84
