### PR TITLE
Avoid fast pins IO on RTOS based boards

### DIFF
--- a/Adafruit_SPIDevice.h
+++ b/Adafruit_SPIDevice.h
@@ -78,9 +78,8 @@ typedef uint32_t BusIO_PortMask;
 #define BUSIO_USE_FAST_PINIO
 
 #elif (defined(__arm__) || defined(ARDUINO_FEATHER52)) &&                      \
-    !defined(ARDUINO_ARCH_RP2040) &&                                           \
-    !defined(ARDUINO_SILABS) && !defined(ARDUINO_UNOR4_MINIMA) &&              \
-    !defined(ARDUINO_UNOR4_WIFI)
+    !defined(ARDUINO_ARCH_RP2040) && !defined(ARDUINO_SILABS) &&               \
+    !defined(ARDUINO_UNOR4_MINIMA) && !defined(ARDUINO_UNOR4_WIFI)
 typedef volatile uint32_t BusIO_PortReg;
 typedef uint32_t BusIO_PortMask;
 #if !defined(__ASR6501__) && !defined(__ASR6502__)

--- a/Adafruit_SPIDevice.h
+++ b/Adafruit_SPIDevice.h
@@ -58,6 +58,11 @@ typedef BitOrder BusIOBitOrder;
 // typedef uint32_t BusIO_PortMask;
 //#define BUSIO_USE_FAST_PINIO
 
+#elif defined(__MBED__) || defined(__ZEPHYR__)
+// Boards based on RTOS cores like mbed or Zephyr are not going to expose the
+// low level registers needed for fast pin manipulation
+#undef BUSIO_USE_FAST_PINIO
+
 #elif defined(ARDUINO_ARCH_XMC)
 #undef BUSIO_USE_FAST_PINIO
 
@@ -73,7 +78,7 @@ typedef uint32_t BusIO_PortMask;
 #define BUSIO_USE_FAST_PINIO
 
 #elif (defined(__arm__) || defined(ARDUINO_FEATHER52)) &&                      \
-    !defined(ARDUINO_ARCH_MBED) && !defined(ARDUINO_ARCH_RP2040) &&            \
+    !defined(ARDUINO_ARCH_RP2040) &&                                           \
     !defined(ARDUINO_SILABS) && !defined(ARDUINO_UNOR4_MINIMA) &&              \
     !defined(ARDUINO_UNOR4_WIFI)
 typedef volatile uint32_t BusIO_PortReg;


### PR DESCRIPTION
Better fix than https://github.com/arduino/ArduinoCore-zephyr/pull/6/commits/80943e663f931f9d11c2c5efa67527996d5d5067

@KurtE

Once we are touching this file, I'd also take a look at why UNO R4 is not in the FAST_IO path (see https://github.com/adafruit/Adafruit_BusIO/commit/d5aa1a353ec505fc6dc10ac8d672bf8d3a3878f1#r150329231 )