### PR TITLE
Update CMakeLists.txt to include "Adafruit_GenericDevice.cpp"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 cmake_minimum_required(VERSION 3.5)
 
-idf_component_register(SRCS "Adafruit_I2CDevice.cpp" "Adafruit_BusIO_Register.cpp" "Adafruit_SPIDevice.cpp" 
+idf_component_register(SRCS "Adafruit_I2CDevice.cpp" "Adafruit_BusIO_Register.cpp" "Adafruit_SPIDevice.cpp" "Adafruit_GenericDevice.cpp"
                        INCLUDE_DIRS "."
                        REQUIRES arduino-esp32)
 


### PR DESCRIPTION
Missing source file "Adafruit_GenericDevice.cpp"

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

**Issue**
When using Adafruit_BusIO as a component in an ESP32 project that uses CMake for the build, the compilation will fail with this error:
  ```
  Adafruit_BusIO_Register.cpp:245:(.text._ZN23Adafruit_BusIO_Register4readEPhh+0xaa): undefined reference to `Adafruit_GenericDevice::readRegister(unsigned char*, unsigned char, unsigned char*, unsigned short)'
  ```
**Resolution**
Add the missing reference to the source file 'Adafruit_GenericDevice.cpp' to CMakesLists.txt

**Testing**
Tested on a Windows 11 PC with Espressif IDE (inside of Visual Studio Code). Ran `idf.py build` 
Error prior to change, successful build after the change
