### PR TITLE
Add PORTDUINO check to Adafruit_SPIDevice.h

### DIFF
--- a/Adafruit_SPIDevice.h
+++ b/Adafruit_SPIDevice.h
@@ -79,7 +79,8 @@ typedef uint32_t BusIO_PortMask;
 
 #elif (defined(__arm__) || defined(ARDUINO_FEATHER52)) &&                      \
     !defined(ARDUINO_ARCH_RP2040) && !defined(ARDUINO_SILABS) &&               \
-    !defined(ARDUINO_UNOR4_MINIMA) && !defined(ARDUINO_UNOR4_WIFI) && !defined(PORTDUINO)
+    !defined(ARDUINO_UNOR4_MINIMA) && !defined(ARDUINO_UNOR4_WIFI) &&          \
+    !defined(PORTDUINO)
 typedef volatile uint32_t BusIO_PortReg;
 typedef uint32_t BusIO_PortMask;
 #if !defined(__ASR6501__) && !defined(__ASR6502__)

--- a/Adafruit_SPIDevice.h
+++ b/Adafruit_SPIDevice.h
@@ -79,7 +79,7 @@ typedef uint32_t BusIO_PortMask;
 
 #elif (defined(__arm__) || defined(ARDUINO_FEATHER52)) &&                      \
     !defined(ARDUINO_ARCH_RP2040) && !defined(ARDUINO_SILABS) &&               \
-    !defined(ARDUINO_UNOR4_MINIMA) && !defined(ARDUINO_UNOR4_WIFI)
+    !defined(ARDUINO_UNOR4_MINIMA) && !defined(ARDUINO_UNOR4_WIFI) && !defined(PORTDUINO)
 typedef volatile uint32_t BusIO_PortReg;
 typedef uint32_t BusIO_PortMask;
 #if !defined(__ASR6501__) && !defined(__ASR6502__)


### PR DESCRIPTION
The PORTDUINO target on an ARMv7 Raspberry Pi was triggering the defined(__arm__) code block, and failing compilation as a result. Quick fix to check for PORTDUINO, and avoid the BUSIO_USE_FAST_PINIO path.