### PR TITLE
Add end() for GenericDevice

### DIFF
--- a/Adafruit_GenericDevice.cpp
+++ b/Adafruit_GenericDevice.cpp
@@ -34,6 +34,14 @@ bool Adafruit_GenericDevice::begin(void) {
   return true;
 }
 
+/*!
+@brief Marks the GenericDevice as no longer in use.
+@note: Since this is a GenericDevice, if you are using this with a Serial
+object, this does NOT disable serial communication or release the RX/TX pins.
+That must be done manually by calling Serial.end().
+*/
+void Adafruit_GenericDevice::end(void) { _begun = false; }
+
 /*! @brief Write a buffer of data
    @param buffer Pointer to buffer of data to write
    @param len Number of bytes to write

--- a/Adafruit_GenericDevice.h
+++ b/Adafruit_GenericDevice.h
@@ -27,6 +27,7 @@ public:
       busio_genericdevice_writereg_t writereg_func = nullptr);
 
   bool begin(void);
+  void end(void);
 
   bool read(uint8_t *buffer, size_t len);
   bool write(const uint8_t *buffer, size_t len);

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit BusIO
-version=1.17.1
+version=1.17.2
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=This is a library for abstracting away UART, I2C and SPI interfacing


### PR DESCRIPTION
@ladyada This adds an end() function for GenericDevice. Since GenericDevice takes in a generic `obj`, and we do not know what `obj` is abstracting, all this function does is toggle the `begin` boolean.

If a user is interfacing with `GenericDevice` from within a class, like `UartDevice` in your example, they should implement `end()` for their specific transport (i.e: Serial) within that class. I've made a NOTE in the comment.

Resolves: https://github.com/adafruit/Adafruit_BusIO/issues/143