### PR TITLE
update sw spi enum

### DIFF
--- a/Adafruit_SPIDevice.h
+++ b/Adafruit_SPIDevice.h
@@ -10,7 +10,7 @@
 #define BUSIO_HAS_HW_SPI
 #else
 // SW SPI ONLY
-enum { SPI_MODE0, SPI_MODE1, SPI_MODE2, _SPI_MODE4 };
+enum { SPI_MODE0, SPI_MODE1, SPI_MODE2, SPI_MODE3 };
 typedef uint8_t SPIClass;
 #endif
 


### PR DESCRIPTION
@ladyada [trinket_5v](https://github.com/adafruit/Adafruit_Learning_System_Guides/actions/runs/17849041383/job/50754009953#step:7:379) and [gemma](https://github.com/adafruit/Adafruit_Learning_System_Guides/actions/runs/17849041383/job/50754009883#step:7:957) learn CI runs started failing with the newest release of busio because the software spi enum did not include `SPI_MODE3`:

```
Arduino\libraries\Adafruit_BusIO\Adafruit_SPIDevice.cpp: In member function 'void Adafruit_SPIDevice::transfer(uint8_t*, size_t)':
Arduino\libraries\Adafruit_BusIO\Adafruit_SPIDevice.cpp:219:31: error: 'SPI_MODE3' was not declared in this scope
       } else if (_dataMode == SPI_MODE3) {
                               ^~~~~~~~~
Arduino\libraries\Adafruit_BusIO\Adafruit_SPIDevice.cpp:219:31: note: suggested alternative: 'SPI_MODE2'
       } else if (_dataMode == SPI_MODE3) {
                               ^~~~~~~~~
                               SPI_MODE2
```

i updated the enum and that fixes the error locally