### PR TITLE
Allow more than 255 byte register reads

### DIFF
--- a/Adafruit_BusIO_Register.cpp
+++ b/Adafruit_BusIO_Register.cpp
@@ -111,8 +111,8 @@ Adafruit_BusIO_Register::Adafruit_BusIO_Register(
 /*!
  *    @brief  Write a buffer of data to the register location
  *    @param  buffer Pointer to data to write
- *    @param  len Number of bytes to write (don't exceed maxbuffersize() 
- * which may be as small as 32 bytes)
+ *    @param  len Number of bytes to write - don't exceed maxbuffersize()
+ * which may be as small as 32 bytes
  *    @return True on successful write (only really useful for I2C as SPI is
  * uncheckable)
  */

--- a/Adafruit_BusIO_Register.cpp
+++ b/Adafruit_BusIO_Register.cpp
@@ -111,7 +111,8 @@ Adafruit_BusIO_Register::Adafruit_BusIO_Register(
 /*!
  *    @brief  Write a buffer of data to the register location
  *    @param  buffer Pointer to data to write
- *    @param  len Number of bytes to write (don't exceed maxbuffersize() which may be as small as 32 bytes)
+ *    @param  len Number of bytes to write (don't exceed maxbuffersize() 
+ * which may be as small as 32 bytes)
  *    @return True on successful write (only really useful for I2C as SPI is
  * uncheckable)
  */

--- a/Adafruit_BusIO_Register.cpp
+++ b/Adafruit_BusIO_Register.cpp
@@ -111,11 +111,11 @@ Adafruit_BusIO_Register::Adafruit_BusIO_Register(
 /*!
  *    @brief  Write a buffer of data to the register location
  *    @param  buffer Pointer to data to write
- *    @param  len Number of bytes to write
+ *    @param  len Number of bytes to write (don't exceed maxbuffersize() which may be as small as 32 bytes)
  *    @return True on successful write (only really useful for I2C as SPI is
  * uncheckable)
  */
-bool Adafruit_BusIO_Register::write(uint8_t *buffer, uint8_t len) {
+bool Adafruit_BusIO_Register::write(uint8_t *buffer, size_t len) {
   uint8_t addrbuffer[2] = {(uint8_t)(_address & 0xFF),
                            (uint8_t)(_address >> 8)};
   if (_i2cdevice) {
@@ -216,7 +216,7 @@ uint32_t Adafruit_BusIO_Register::readCached(void) { return _cached; }
    @param len Number of bytes to read into the buffer
    @return true on successful read, otherwise false
 */
-bool Adafruit_BusIO_Register::read(uint8_t *buffer, uint8_t len) {
+bool Adafruit_BusIO_Register::read(uint8_t *buffer, size_t len) {
   uint8_t addrbuffer[2] = {(uint8_t)(_address & 0xFF),
                            (uint8_t)(_address >> 8)};
   if (_i2cdevice) {

--- a/Adafruit_BusIO_Register.h
+++ b/Adafruit_BusIO_Register.h
@@ -63,12 +63,12 @@ public:
                           uint8_t byteorder = LSBFIRST,
                           uint8_t address_width = 1);
 
-  bool read(uint8_t *buffer, uint8_t len);
+  bool read(uint8_t *buffer, size_t len);
   bool read(uint8_t *value);
   bool read(uint16_t *value);
   uint32_t read(void);
   uint32_t readCached(void);
-  bool write(uint8_t *buffer, uint8_t len);
+  bool write(uint8_t *buffer, size_t len);
   bool write(uint32_t value, uint8_t numbytes = 0);
 
   uint8_t width(void);

--- a/Adafruit_I2CDevice.cpp
+++ b/Adafruit_I2CDevice.cpp
@@ -174,7 +174,7 @@ bool Adafruit_I2CDevice::write(const uint8_t *buffer, size_t len, bool stop,
 
 /*!
  *    @brief  Read from I2C into a buffer from the I2C device.
- *    Cannot be more than maxBufferSize() bytes.
+ *    Unlimited length, in chunks of maxBufferSize() bytes.
  *    @param  buffer Pointer to buffer of data to read into
  *    @param  len Number of bytes from buffer to read.
  *    @param  stop Whether to send an I2C STOP signal on read
@@ -235,7 +235,7 @@ bool Adafruit_I2CDevice::_read(uint8_t *buffer, size_t len, bool stop) {
 
 /*!
  *    @brief  Write some data, then read some data from I2C into another buffer.
- *    Cannot be more than maxBufferSize() bytes. The buffers can point to
+ *    Written buffer cannot be more than maxBufferSize() bytes. The buffers can point to
  *    same/overlapping locations.
  *    @param  write_buffer Pointer to buffer of data to write from
  *    @param  write_len Number of bytes from buffer to write.

--- a/Adafruit_I2CDevice.cpp
+++ b/Adafruit_I2CDevice.cpp
@@ -235,7 +235,7 @@ bool Adafruit_I2CDevice::_read(uint8_t *buffer, size_t len, bool stop) {
 
 /*!
  *    @brief  Write some data, then read some data from I2C into another buffer.
- *    Written buffer cannot be more than maxBufferSize() bytes. The buffers 
+ *    Written buffer cannot be more than maxBufferSize() bytes. The buffers
  *    can point to same/overlapping locations.
  *    @param  write_buffer Pointer to buffer of data to write from
  *    @param  write_len Number of bytes from buffer to write.

--- a/Adafruit_I2CDevice.cpp
+++ b/Adafruit_I2CDevice.cpp
@@ -15,7 +15,7 @@ Adafruit_I2CDevice::Adafruit_I2CDevice(uint8_t addr, TwoWire *theWire) {
   _maxBufferSize = 250; // as defined in Wire.h's RingBuffer
 #elif defined(ESP32)
   _maxBufferSize = I2C_BUFFER_LENGTH;
-#elif defined(TwoWireKinetis_h) || defined(TwoWireIMXRT_h) //Teensy 3.x || 4.x
+#elif defined(TwoWireKinetis_h) || defined(TwoWireIMXRT_h) // Teensy 3.x || 4.x
   _maxBufferSize = BUFFER_LENGTH;
 #else
   _maxBufferSize = 32;

--- a/Adafruit_I2CDevice.cpp
+++ b/Adafruit_I2CDevice.cpp
@@ -15,6 +15,8 @@ Adafruit_I2CDevice::Adafruit_I2CDevice(uint8_t addr, TwoWire *theWire) {
   _maxBufferSize = 250; // as defined in Wire.h's RingBuffer
 #elif defined(ESP32)
   _maxBufferSize = I2C_BUFFER_LENGTH;
+#elif defined(TwoWireKinetis_h) || defined(TwoWireIMXRT_h) //Teensy 3.x || 4.x
+  _maxBufferSize = BUFFER_LENGTH;
 #else
   _maxBufferSize = 32;
 #endif

--- a/Adafruit_I2CDevice.cpp
+++ b/Adafruit_I2CDevice.cpp
@@ -235,8 +235,8 @@ bool Adafruit_I2CDevice::_read(uint8_t *buffer, size_t len, bool stop) {
 
 /*!
  *    @brief  Write some data, then read some data from I2C into another buffer.
- *    Written buffer cannot be more than maxBufferSize() bytes. The buffers can point to
- *    same/overlapping locations.
+ *    Written buffer cannot be more than maxBufferSize() bytes. The buffers 
+ *    can point to same/overlapping locations.
  *    @param  write_buffer Pointer to buffer of data to write from
  *    @param  write_len Number of bytes from buffer to write.
  *    @param  read_buffer Pointer to buffer of data to read into.

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit BusIO
-version=1.17.4
+version=1.17.5
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=This is a library for abstracting away UART, I2C and SPI interfacing


### PR DESCRIPTION
Change the type for reading length to size_t so that more than 255 bytes can be read in one operation. (Writing more than 255 is a little more complex due to the small (usually 32 byte) buffer used inside the Wire.h library.)

The underlying I2C and SPI libraries use size_t for the size of reads and writes, so why does the BusIO have this limit? Yes, it's pretty rare to read this much but there are some devices where this is a limitation on the use of the device. This commit also updates some of the Docygen comments on the read/write functions to make it clear when the maxbuffersize() applies.
